### PR TITLE
Fix chat publisher output and cleanup messages

### DIFF
--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -67,8 +67,7 @@ export const ChatMessages = () => {
                                                             {message.created ? (
                                                                 <Typography variant="body2" color="grey.400" mb={1}>
                                                                     {message.uid === CHATBOT_UID ? "XRisk-Chabot" : otherChatMemberName},{' '}
-                                                                    {formatLastActivity(message.created)}{' '}
-                                                                    her
+                                                                    {formatLastActivity(message.created)}
                                                                 </Typography>
                                                             ) : null}
                                                             {message.type === MessageTypeEnum.TEXT ? (

--- a/src/components/chat/chatbot.ts
+++ b/src/components/chat/chatbot.ts
@@ -46,13 +46,16 @@ export class Chatbot {
             return;
         }
 
+        const publisherName = risk.publisher?.name || "Unbekannter Anbieter";
+        const riskTypes = Array.isArray(risk.type) ? risk.type.join(', ') : risk.type;
+
         this.basePrompt += "Risiko: {" +
             "Name: " + risk.name + ", " +
             "Beschreibung: " + risk.description + ", " +
-            "Typ: " + risk.type + ", " +
+            "Typ: " + riskTypes + ", " +
             "Wert: " + risk.value + ", " +
             "Veröffentlichungsdatum: " + risk.publishedAt + ", " +
-            "Veröffentlicher: " + risk.publisher + ", " +
+            "Veröffentlicher: " + publisherName + ", " +
             "Ablaufdatum: " + risk.declinationDate + ", " +
             "Erstellt am: " + risk.createdAt + ", " +
             "Aktualisiert am: " + risk.updatedAt + "}; "


### PR DESCRIPTION
## Summary
- fix risk publisher info in Chatbot
- remove stray placeholder text in ChatMessages

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module '@reduxjs/toolkit'...)*

------
https://chatgpt.com/codex/tasks/task_e_684ee301e2548333be762e8165680d2e