### PR TITLE
Google-only auth and profile completion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,8 @@ import {Navigate, Route, Routes} from "react-router-dom";
 
 import {Landing} from "./pages/landing/landing";
 import {LoginForm} from "./pages/authentication/sign-in";
-import {RegistrationForm} from "./pages/authentication/sign-up";
 import {ForgotPassword} from "./pages/authentication/forgot-password";
+import { CompleteProfile } from "./pages/complete-profile/complete-profile";
 import {RiskOverview} from "./pages/risk-overview/risk-overview";
 import {Layout} from "./components/layout/layout";
 import {Legal} from "./pages/formalities/legal";
@@ -39,9 +39,9 @@ function App() {
             <Routes>
                 <Route path="/" element={<Landing />} />
                 <Route path={`/${ROUTES.SIGN_IN}`} element={<LoginForm />} />
-                <Route path={`/${ROUTES.SIGN_UP}`} element={<RegistrationForm />} />
                 <Route path={`/${ROUTES.FORGOT_PASSWORD}`} element={<ForgotPassword />} />
                 <Route path="/verify-email" element={<VerifyEmail />} />
+                <Route path={`/${ROUTES.COMPLETE_PROFILE}`} element={<CompleteProfile />} />
 
                 {/* Private routes */}
                 <Route path={`/${ROUTES.DASHBOARD}`} element={<PrivateRoute><Dashboard /></PrivateRoute>} />

--- a/src/pages/authentication/sign-in.tsx
+++ b/src/pages/authentication/sign-in.tsx
@@ -1,20 +1,12 @@
 import React, { useState } from "react";
-import {
-  Box, Button, TextField, Typography, Snackbar, Alert, CircularProgress
-} from "@mui/material";
-import {
-  signInWithEmailAndPassword,
-  sendEmailVerification,
-  GoogleAuthProvider,
-  signInWithPopup
-} from "firebase/auth";
-import {auth, db} from "../../firebase_config";
-import { useNavigate, Link } from "react-router-dom";
-import {doc, setDoc} from "firebase/firestore";
+import { Box, Button, Typography, Snackbar, Alert, CircularProgress } from "@mui/material";
+import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
+import { auth, db } from "../../firebase_config";
+import { useNavigate } from "react-router-dom";
+import { collection, getDocs, query, where } from "firebase/firestore";
+import { ROUTES } from "../../routing/routes";
 
 export const LoginForm: React.FC = () => {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
@@ -27,32 +19,6 @@ export const LoginForm: React.FC = () => {
     setSnackbarOpen(true);
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-    setErrorMsg(null);
-    try {
-      const userCredential = await signInWithEmailAndPassword(auth, email, password);
-      const user = userCredential.user;
-      if (!user.emailVerified) {
-        await sendEmailVerification(user);
-        await auth.signOut();
-        showError("Bitte bestätige deine E-Mail-Adresse. Wir haben dir eine neue E-Mail geschickt.");
-        setLoading(false);
-        return;
-      }
-      navigate("/");
-    } catch (err: any) {
-      const msg = err.code === "auth/user-not-found"
-          ? "Kein Benutzer mit dieser E-Mail gefunden."
-          : err.code === "auth/wrong-password"
-              ? "Falsches Passwort."
-              : "Anmeldung fehlgeschlagen.";
-      showError(msg);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const handleGoogleSignIn = async () => {
     setLoading(true);
@@ -60,23 +26,13 @@ export const LoginForm: React.FC = () => {
       const provider = new GoogleAuthProvider();
       const result = await signInWithPopup(auth, provider);
       const user = result.user;
-      if (!user.emailVerified) {
-        await sendEmailVerification(user);
-        await auth.signOut();
-        showError("Bitte bestätige deine E-Mail-Adresse. Wir haben dir eine E-Mail geschickt.");
-        return;
+      const profileQuery = query(collection(db, "userProfiles"), where("uid", "==", user.uid));
+      const profileSnapshot = await getDocs(profileQuery);
+      if (profileSnapshot.empty) {
+        navigate(`/${ROUTES.COMPLETE_PROFILE}`);
+      } else {
+        navigate("/");
       }
-
-      await setDoc(doc(db, "users", user.uid), {
-        uid: user.uid,
-        email: user.email,
-        displayName: user.displayName,
-        provider: "google",
-        createdAt: new Date().toISOString(),
-        role: "member"
-      }, { merge: true });
-
-      navigate("/");
     } catch (err: any) {
       showError("Google-Anmeldung fehlgeschlagen.");
     } finally {
@@ -85,50 +41,19 @@ export const LoginForm: React.FC = () => {
   };
 
   return (
-      <Box component="form" onSubmit={handleSubmit} sx={{ mt: 3, px: 2, maxWidth: 400, mx: "auto" }}>
+      <Box sx={{ mt: 3, px: 2, maxWidth: 400, mx: "auto" }}>
         <Typography variant="h5" gutterBottom>
           Login
         </Typography>
-        <TextField
-            fullWidth
-            required
-            label="E-Mail"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            sx={{ mb: 2 }}
-        />
-        <TextField
-            fullWidth
-            required
-            label="Passwort"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            sx={{ mb: 2 }}
-        />
-        <Button
-            type="submit"
-            variant="contained"
-            color="primary"
-            fullWidth
-            disabled={loading}
-            startIcon={loading ? <CircularProgress size={20} /> : null}
-            sx={{ mb: 1 }}
-        >
-          Einloggen
-        </Button>
         <Button
             variant="outlined"
             fullWidth
             onClick={handleGoogleSignIn}
             disabled={loading}
+            startIcon={loading ? <CircularProgress size={20} /> : null}
         >
           Mit Google anmelden
         </Button>
-        <Typography variant="body2" sx={{ mt: 1 }}>
-          <Link to="/forgot-password">Passwort vergessen?</Link>
-        </Typography>
         <Snackbar open={snackbarOpen} autoHideDuration={6000} onClose={handleSnackbarClose}>
           <Alert severity="error" onClose={handleSnackbarClose} sx={{ width: "100%" }}>
             {errorMsg}

--- a/src/pages/complete-profile/complete-profile.tsx
+++ b/src/pages/complete-profile/complete-profile.tsx
@@ -1,0 +1,219 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  Grid,
+  MenuItem,
+  TextField,
+  Typography,
+  Snackbar,
+  Alert
+} from "@mui/material";
+import { collection, getDocs, query, where, setDoc, doc } from "firebase/firestore";
+import { useNavigate } from "react-router-dom";
+import { auth, db } from "../../firebase_config";
+import { ROUTES } from "../../routing/routes";
+
+const helperTexts: Record<string, string> = {
+  firstName: "Mindestens 2 Zeichen.",
+  lastName: "Mindestens 2 Zeichen.",
+  birthDate: "Du musst mindestens 18 Jahre alt sein.",
+  address: "Mindestens 2 Zeichen.",
+  phone: "Nur Ziffern, mind. 7 Stellen.",
+  username: "Mindestens 3 Zeichen.",
+  gender: "Bitte auswählen.",
+  nationality: "Bitte auswählen.",
+  language: "Bitte auswählen."
+};
+
+const calculateAge = (birthDate: string): number => {
+  const today = new Date();
+  const birth = new Date(birthDate);
+  let age = today.getFullYear() - birth.getFullYear();
+  const m = today.getMonth() - birth.getMonth();
+  if (m < 0 || (m === 0 && today.getDate() < birth.getDate())) age--;
+  return age;
+};
+
+const isValidPhone = (phone: string) => /^\+?[0-9]{7,15}$/.test(phone);
+
+export const CompleteProfile: React.FC = () => {
+  const [formData, setFormData] = useState({
+    firstName: "",
+    lastName: "",
+    birthDate: "",
+    gender: "",
+    nationality: "",
+    address: "",
+    phone: "",
+    username: "",
+    language: "",
+    interests: ""
+  });
+  const [agreed, setAgreed] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, boolean>>({});
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState("");
+  const navigate = useNavigate();
+
+  const handleSnackbarClose = () => setSnackbarOpen(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+    setFieldErrors({ ...fieldErrors, [e.target.name]: false });
+  };
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    const trimmed = value.trim();
+    const fail = (condition: boolean) => condition && setFieldErrors(prev => ({ ...prev, [name]: true }));
+
+    switch (name) {
+      case "firstName":
+      case "lastName":
+      case "address":
+        fail(trimmed.length < 2); break;
+      case "birthDate":
+        fail(calculateAge(trimmed) < 18); break;
+      case "phone":
+        fail(!isValidPhone(trimmed)); break;
+      case "username":
+        fail(trimmed.length < 3); break;
+      case "gender":
+      case "nationality":
+      case "language":
+        fail(trimmed.length === 0); break;
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    let hasError = false;
+
+    const checks: [keyof typeof formData, () => boolean][] = [
+      ["birthDate", () => calculateAge(formData.birthDate) < 18],
+      ["phone", () => !isValidPhone(formData.phone)],
+      ["username", () => formData.username.trim().length < 3],
+      ["firstName", () => formData.firstName.trim().length < 2],
+      ["lastName", () => formData.lastName.trim().length < 2],
+      ["address", () => formData.address.trim().length < 2],
+      ["gender", () => !formData.gender],
+      ["nationality", () => !formData.nationality],
+      ["language", () => !formData.language]
+    ];
+
+    for (const [key, condition] of checks) {
+      if (condition()) {
+        setFieldErrors(prev => ({ ...prev, [key]: true }));
+        hasError = true;
+      }
+    }
+
+    if (!agreed) {
+      setSnackbarMessage("Du musst den AGB und der Datenschutzerklärung zustimmen.");
+      setSnackbarOpen(true);
+      return;
+    }
+
+    if (hasError) return;
+
+    if (!auth.currentUser) return;
+
+    // Prüfen, ob der Benutzername bereits existiert
+    const usernameQuery = query(
+      collection(db, "userProfiles"),
+      where("profile.username", "==", formData.username)
+    );
+    const usernameSnapshot = await getDocs(usernameQuery);
+    if (!usernameSnapshot.empty) {
+      setSnackbarMessage("Benutzername bereits vergeben.");
+      setSnackbarOpen(true);
+      return;
+    }
+
+    await setDoc(doc(db, "userProfiles", auth.currentUser.uid), {
+      id: auth.currentUser.uid,
+      uid: auth.currentUser.uid,
+      profile: formData,
+      createdAt: new Date().toISOString()
+    }, { merge: true });
+
+    navigate("/");
+  };
+
+  const getError = (field: keyof typeof formData) => fieldErrors[field] || false;
+  const getHelper = (field: keyof typeof formData) => getError(field) ? helperTexts[field] : " ";
+
+  return (
+      <Box component="form" onSubmit={handleSubmit} sx={{ mt: 3, px: 2, maxWidth: 600, mx: "auto" }}>
+        <Typography variant="h5" gutterBottom>Profil vervollständigen</Typography>
+        <Grid container spacing={2}>
+          {Object.entries(formData).map(([key, value]) => (
+              <Grid item xs={12} key={key}>
+                <TextField
+                    fullWidth
+                    required={key !== "interests"}
+                    name={key}
+                    label={{
+                      firstName: "Vorname",
+                      lastName: "Nachname",
+                      birthDate: "Geburtsdatum",
+                      gender: "Geschlecht",
+                      nationality: "Nationalität",
+                      address: "Adresse",
+                      phone: "Telefonnummer",
+                      username: "Benutzername",
+                      language: "Sprache",
+                      interests: "Interessen / Vorstellung"
+                    }[key] || key}
+                    type={key === "birthDate" ? "date" : "text"}
+                    value={value}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={getError(key as keyof typeof formData)}
+                    helperText={getHelper(key as keyof typeof formData)}
+                    multiline={key === "interests"}
+                    rows={key === "interests" ? 3 : undefined}
+                    InputLabelProps={key === "birthDate" ? { shrink: true } : undefined}
+                    select={["gender", "nationality", "language"].includes(key)}
+                >
+                  {key === "gender" && ["männlich", "weiblich"].map(g => (
+                      <MenuItem key={g} value={g}>{g}</MenuItem>
+                  ))}
+                  {key === "nationality" && [
+                    "Deutschland 🇩🇪", "Türkei 🇹🇷", "Syrien 🇸🇾", "Afghanistan 🇦🇫", "Marokko 🇲🇦"
+                  ].map(n => (
+                      <MenuItem key={n} value={n}>{n}</MenuItem>
+                  ))}
+                  {key === "language" && [
+                    { code: "de", label: "Deutsch 🇩🇪" },
+                    { code: "en", label: "Englisch 🇬🇧" },
+                    { code: "ar", label: "Arabisch 🇸🇦" },
+                    { code: "fr", label: "Französisch 🇫🇷" }
+                  ].map(l => (
+                      <MenuItem key={l.code} value={l.code}>{l.label}</MenuItem>
+                  ))}
+                </TextField>
+              </Grid>
+          ))}
+          <Grid item xs={12}>
+            <FormControlLabel
+                control={<Checkbox checked={agreed} onChange={() => setAgreed(!agreed)} />}
+                label="Ich stimme den AGB und der Datenschutzerklärung zu."
+            />
+          </Grid>
+        </Grid>
+        <Button type="submit" variant="contained" color="primary" sx={{ mt: 2 }}>
+          Speichern
+        </Button>
+        <Snackbar open={snackbarOpen} autoHideDuration={6000} onClose={handleSnackbarClose}>
+          <Alert severity="error" onClose={handleSnackbarClose} sx={{ width: '100%' }}>
+            {snackbarMessage}
+          </Alert>
+        </Snackbar>
+      </Box>
+  );
+};
+

--- a/src/routing/private-route.tsx
+++ b/src/routing/private-route.tsx
@@ -1,13 +1,31 @@
-import React from "react";
-import {Navigate} from "react-router-dom";
-import {ROUTES} from "./routes";
+import React, { useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
+import { ROUTES } from "./routes";
 import { Box, CircularProgress } from "@mui/material";
 import { useAuth } from "../context/AuthContext";
+import { collection, getDocs, query, where } from "firebase/firestore";
+import { db } from "../firebase_config";
 
 export const PrivateRoute = ({ children }: { children: JSX.Element }) => {
     const { user, loading } = useAuth();
+    const [checking, setChecking] = useState(true);
+    const [hasProfile, setHasProfile] = useState(false);
 
-    if (loading) {
+    useEffect(() => {
+        const checkProfile = async () => {
+            if (user) {
+                const q = query(collection(db, "userProfiles"), where("uid", "==", user.uid));
+                const snapshot = await getDocs(q);
+                setHasProfile(!snapshot.empty);
+            }
+            setChecking(false);
+        };
+        if (!loading) {
+            checkProfile();
+        }
+    }, [user, loading]);
+
+    if (loading || checking) {
         return (
             <Box display="flex" justifyContent="center" mt={4}>
                 <CircularProgress />
@@ -15,5 +33,7 @@ export const PrivateRoute = ({ children }: { children: JSX.Element }) => {
         );
     }
 
-    return user ? children : <Navigate to={`/${ROUTES.SIGN_IN}`} />;
+    if (!user) return <Navigate to={`/${ROUTES.SIGN_IN}`} />;
+    if (!hasProfile) return <Navigate to={`/${ROUTES.COMPLETE_PROFILE}`} />;
+    return children;
 };

--- a/src/routing/routes.ts
+++ b/src/routing/routes.ts
@@ -1,6 +1,5 @@
 export const ROUTES = {
     SIGN_IN: 'sign-in',
-    SIGN_UP: 'sign-up',
     FORGOT_PASSWORD: 'forgot-password',
     ABOUT: 'about',
     CHAT: 'chat',
@@ -25,5 +24,6 @@ export const ROUTES = {
     DOCUMENTS: 'documents',
     REPORTS: 'reports',
     ONBOARDING: 'onboarding',
+    COMPLETE_PROFILE: 'complete-profile',
 
 };


### PR DESCRIPTION
## Summary
- remove sign-up flow and rely solely on Google login
- add post-login profile completion form
- guard private routes until profile data is filled

## Testing
- `npm install`
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684f95948ed08333af9d71f264481e2b