### PR TITLE
Fix missing sign up route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import {Navigate, Route, Routes} from "react-router-dom";
 
 import {Landing} from "./pages/landing/landing";
 import {LoginForm} from "./pages/authentication/sign-in";
+import {RegistrationForm} from "./pages/authentication/sign-up";
 import {ForgotPassword} from "./pages/authentication/forgot-password";
 import { CompleteProfile } from "./pages/complete-profile/complete-profile";
 import {RiskOverview} from "./pages/risk-overview/risk-overview";
@@ -39,6 +40,7 @@ function App() {
             <Routes>
                 <Route path="/" element={<Landing />} />
                 <Route path={`/${ROUTES.SIGN_IN}`} element={<LoginForm />} />
+                <Route path={`/${ROUTES.SIGN_UP}`} element={<RegistrationForm />} />
                 <Route path={`/${ROUTES.FORGOT_PASSWORD}`} element={<ForgotPassword />} />
                 <Route path="/verify-email" element={<VerifyEmail />} />
                 <Route path={`/${ROUTES.COMPLETE_PROFILE}`} element={<CompleteProfile />} />

--- a/src/routing/routes.ts
+++ b/src/routing/routes.ts
@@ -1,5 +1,6 @@
 export const ROUTES = {
     SIGN_IN: 'sign-in',
+    SIGN_UP: 'sign-up',
     FORGOT_PASSWORD: 'forgot-password',
     ABOUT: 'about',
     CHAT: 'chat',


### PR DESCRIPTION
## Summary
- add `SIGN_UP` route constant
- support signup in routing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f988020288333b33799f8dc7f50da