### PR TITLE
Fix footer position

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -8,7 +8,7 @@ import XIcon from '@mui/icons-material/X';
 export const Footer = () => {
     return (
         <React.Fragment>
-            <Grid container style={{backgroundColor: "#1F271B", padding: "60px 80px 100px 80px"}}>
+            <Grid container style={{backgroundColor: "#1F271B", padding: "60px 80px 100px 80px", position: "fixed", bottom: 0, left: 0, width: "100%"}}>
                 <Grid size={2}>
                     <img src={Logo} style={{width: "60px", height: "50px"}} alt="logo"/>
                 </Grid>

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -8,10 +8,12 @@ export interface LayoutProps {
 
 export const Layout = (props: LayoutProps) => {
     return (
-        <React.Fragment>
+        <div className="layout">
             <Header/>
+            <main className="main-content">
                 {props.children}
+            </main>
             <Footer />
-        </React.Fragment>
+        </div>
     )
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,27 @@
-body {
+html, body, #root {
+  height: 100%;
   margin: 0;
   padding: 0;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+#root {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.layout {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.main-content {
+  flex: 1;
 }


### PR DESCRIPTION
## Summary
- make Layout use flexbox layout so footer sits at the bottom
- style page and root containers to fill the viewport
- set footer container as fixed at the bottom of the page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684fad13fea483339c05108c51b5a412