### PR TITLE
Fix ESLint unused import error

### DIFF
--- a/src/pages/complete-profile/complete-profile.tsx
+++ b/src/pages/complete-profile/complete-profile.tsx
@@ -13,7 +13,7 @@ import {
 } from "@mui/material";
 import { collection, getDocs, query, where, setDoc, doc } from "firebase/firestore";
 import { useNavigate } from "react-router-dom";
-import { auth, db } from "../../firebase_config";
+import { db } from "../../firebase_config";
 import { useAuth } from "../../context/AuthContext";
 
 const helperTexts: Record<string, string> = {


### PR DESCRIPTION
## Summary
- drop unused `auth` import from `CompleteProfile` page

## Testing
- `npm test --silent -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb1f10074833389224a3d18513a1e