### PR TITLE
Allow partial profile saving

### DIFF
--- a/src/routing/private-route.tsx
+++ b/src/routing/private-route.tsx
@@ -42,7 +42,7 @@ export const PrivateRoute = ({ children }: { children: JSX.Element }) => {
     }
 
     if (!user) return <Navigate to={`/${ROUTES.SIGN_IN}`} />;
-    const allowed = [`/${ROUTES.DASHBOARD}`, `/${ROUTES.PROFILE}`, `/${ROUTES.COMPLETE_PROFILE}`];
+    const allowed = [`/${ROUTES.COMPLETE_PROFILE}`];
     if (!profileComplete && !allowed.includes(location.pathname)) {
         return <Navigate to={`/${ROUTES.COMPLETE_PROFILE}`} />;
     }


### PR DESCRIPTION
## Summary
- allow partial saving in complete profile form
- restrict navigation for incomplete profiles to the profile completion page

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684fc065f64c8333bee0358684f5aa09