### PR TITLE
Add basic PostgreSQL support

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -29,11 +29,22 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+        <dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/example/backend/Greeting.java
+++ b/backend/src/main/java/com/example/backend/Greeting.java
@@ -1,0 +1,33 @@
+package com.example.backend;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Greeting {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String message;
+
+    public Greeting() {
+    }
+
+    public Greeting(String message) {
+        this.message = message;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/backend/src/main/java/com/example/backend/GreetingController.java
+++ b/backend/src/main/java/com/example/backend/GreetingController.java
@@ -1,0 +1,26 @@
+package com.example.backend;
+
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/greetings")
+@CrossOrigin(origins = "*")
+public class GreetingController {
+    private final GreetingRepository repository;
+
+    public GreetingController(GreetingRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping
+    public List<Greeting> list() {
+        return repository.findAll();
+    }
+
+    @PostMapping
+    public Greeting create(@RequestBody Greeting greeting) {
+        return repository.save(greeting);
+    }
+}

--- a/backend/src/main/java/com/example/backend/GreetingRepository.java
+++ b/backend/src/main/java/com/example/backend/GreetingRepository.java
@@ -1,0 +1,6 @@
+package com.example.backend;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GreetingRepository extends JpaRepository<Greeting, Long> {
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=backend
+spring.datasource.url=jdbc:postgresql://localhost:5432/mansa
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## Summary
- add Spring Data JPA and PostgreSQL driver
- configure datasource in `application.properties`
- create `Greeting` entity and repository
- expose CRUD-style controller at `/api/greetings`

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685544dd18d88333ad884f33d2889522