### PR TITLE
Add risk entity and REST controller

### DIFF
--- a/backend/src/main/java/com/example/backend/Publisher.java
+++ b/backend/src/main/java/com/example/backend/Publisher.java
@@ -1,0 +1,63 @@
+package com.example.backend;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "publishers")
+public class Publisher {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String uid;
+    private String name;
+    private String address;
+    private Integer age;
+
+    public Publisher() {
+    }
+
+    public Publisher(String uid, String name, String address, Integer age) {
+        this.uid = uid;
+        this.name = name;
+        this.address = address;
+        this.age = age;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getUid() {
+        return uid;
+    }
+
+    public void setUid(String uid) {
+        this.uid = uid;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
+
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+}

--- a/backend/src/main/java/com/example/backend/PublisherRepository.java
+++ b/backend/src/main/java/com/example/backend/PublisherRepository.java
@@ -1,0 +1,6 @@
+package com.example.backend;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PublisherRepository extends JpaRepository<Publisher, Long> {
+}

--- a/backend/src/main/java/com/example/backend/Risk.java
+++ b/backend/src/main/java/com/example/backend/Risk.java
@@ -1,0 +1,159 @@
+package com.example.backend;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "risks")
+public class Risk {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Column(length = 2048)
+    private String description;
+
+    @ElementCollection
+    @CollectionTable(name = "risk_types", joinColumns = @JoinColumn(name = "risk_id"))
+    @Column(name = "type")
+    private List<String> type = new ArrayList<>();
+
+    private BigDecimal value;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "publisher_id")
+    private Publisher publisher;
+
+    private LocalDate declinationDate;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime publishedAt;
+    private LocalDateTime withdrawnAt;
+
+    @Enumerated(EnumType.STRING)
+    private RiskStatus status;
+
+    private String riskCategory;
+    private Double riskProbability;
+
+    public Risk() {
+    }
+
+    // getters and setters
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<String> getType() {
+        return type;
+    }
+
+    public void setType(List<String> type) {
+        this.type = type;
+    }
+
+    public BigDecimal getValue() {
+        return value;
+    }
+
+    public void setValue(BigDecimal value) {
+        this.value = value;
+    }
+
+    public Publisher getPublisher() {
+        return publisher;
+    }
+
+    public void setPublisher(Publisher publisher) {
+        this.publisher = publisher;
+    }
+
+    public LocalDate getDeclinationDate() {
+        return declinationDate;
+    }
+
+    public void setDeclinationDate(LocalDate declinationDate) {
+        this.declinationDate = declinationDate;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public LocalDateTime getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(LocalDateTime publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+
+    public LocalDateTime getWithdrawnAt() {
+        return withdrawnAt;
+    }
+
+    public void setWithdrawnAt(LocalDateTime withdrawnAt) {
+        this.withdrawnAt = withdrawnAt;
+    }
+
+    public RiskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(RiskStatus status) {
+        this.status = status;
+    }
+
+    public String getRiskCategory() {
+        return riskCategory;
+    }
+
+    public void setRiskCategory(String riskCategory) {
+        this.riskCategory = riskCategory;
+    }
+
+    public Double getRiskProbability() {
+        return riskProbability;
+    }
+
+    public void setRiskProbability(Double riskProbability) {
+        this.riskProbability = riskProbability;
+    }
+}

--- a/backend/src/main/java/com/example/backend/RiskController.java
+++ b/backend/src/main/java/com/example/backend/RiskController.java
@@ -1,0 +1,60 @@
+package com.example.backend;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/risks")
+@CrossOrigin(origins = "*")
+public class RiskController {
+
+    private final RiskRepository riskRepository;
+    private final PublisherRepository publisherRepository;
+
+    public RiskController(RiskRepository riskRepository, PublisherRepository publisherRepository) {
+        this.riskRepository = riskRepository;
+        this.publisherRepository = publisherRepository;
+    }
+
+    @GetMapping
+    public List<Risk> list() {
+        return riskRepository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public Risk get(@PathVariable Long id) {
+        return riskRepository.findById(id).orElseThrow(() -> new RuntimeException("Risk not found"));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Risk create(@RequestBody Risk risk) {
+        if (risk.getPublisher() != null && risk.getPublisher().getId() == null) {
+            Publisher saved = publisherRepository.save(risk.getPublisher());
+            risk.setPublisher(saved);
+        }
+        return riskRepository.save(risk);
+    }
+
+    @PutMapping("/{id}")
+    public Risk update(@PathVariable Long id, @RequestBody Risk risk) {
+        Risk existing = riskRepository.findById(id).orElseThrow(() -> new RuntimeException("Risk not found"));
+        existing.setName(risk.getName());
+        existing.setDescription(risk.getDescription());
+        existing.setType(risk.getType());
+        existing.setValue(risk.getValue());
+        existing.setDeclinationDate(risk.getDeclinationDate());
+        existing.setStatus(risk.getStatus());
+        existing.setRiskCategory(risk.getRiskCategory());
+        existing.setRiskProbability(risk.getRiskProbability());
+        return riskRepository.save(existing);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        riskRepository.deleteById(id);
+    }
+}

--- a/backend/src/main/java/com/example/backend/RiskRepository.java
+++ b/backend/src/main/java/com/example/backend/RiskRepository.java
@@ -1,0 +1,6 @@
+package com.example.backend;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RiskRepository extends JpaRepository<Risk, Long> {
+}

--- a/backend/src/main/java/com/example/backend/RiskStatus.java
+++ b/backend/src/main/java/com/example/backend/RiskStatus.java
@@ -1,0 +1,7 @@
+public enum RiskStatus {
+    DRAFT,
+    PUBLISHED,
+    DEAL,
+    AGREEMENT,
+    WITHDRAWN
+}


### PR DESCRIPTION
## Summary
- add Risk entity with JPA annotations
- add Publisher entity and repository
- add REST controller for CRUD operations on risks
- configure repository interfaces

## Testing
- `npm test` *(fails: react-scripts not found)*
- `./mvnw package` *(fails: could not resolve dependencies due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685545f4348c8333bb00654769c07049