### PR TITLE
Implement unique username storing via controller

### DIFF
--- a/backend/src/main/java/com/example/backend/UserProfile.java
+++ b/backend/src/main/java/com/example/backend/UserProfile.java
@@ -1,0 +1,122 @@
+package com.example.backend;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "user_profiles", uniqueConstraints = @UniqueConstraint(columnNames = "username"))
+public class UserProfile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String uid;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    private String firstName;
+    private String lastName;
+    private String birthDate;
+    private String gender;
+    private String nationality;
+    private String address;
+    private String phone;
+    private String language;
+    @Column(length = 2048)
+    private String interests;
+
+    public UserProfile() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getUid() {
+        return uid;
+    }
+
+    public void setUid(String uid) {
+        this.uid = uid;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getBirthDate() {
+        return birthDate;
+    }
+
+    public void setBirthDate(String birthDate) {
+        this.birthDate = birthDate;
+    }
+
+    public String getGender() {
+        return gender;
+    }
+
+    public void setGender(String gender) {
+        this.gender = gender;
+    }
+
+    public String getNationality() {
+        return nationality;
+    }
+
+    public void setNationality(String nationality) {
+        this.nationality = nationality;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public String getInterests() {
+        return interests;
+    }
+
+    public void setInterests(String interests) {
+        this.interests = interests;
+    }
+}

--- a/backend/src/main/java/com/example/backend/UserProfileController.java
+++ b/backend/src/main/java/com/example/backend/UserProfileController.java
@@ -1,0 +1,88 @@
+package com.example.backend;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/userProfiles")
+@CrossOrigin(origins = "*")
+public class UserProfileController {
+    private final UserProfileRepository repository;
+
+    public UserProfileController(UserProfileRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping
+    public List<UserProfile> list() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public UserProfile get(@PathVariable Long id) {
+        return repository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    }
+
+    @GetMapping("/check")
+    public boolean checkUsername(@RequestParam String username) {
+        return !repository.existsByUsername(username);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserProfile create(@RequestBody UserProfile profile) {
+        if (repository.existsByUsername(profile.getUsername())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username already taken");
+        }
+        return repository.save(profile);
+    }
+
+    @PutMapping("/{id}")
+    public UserProfile update(@PathVariable Long id, @RequestBody UserProfile profile) {
+        UserProfile existing = repository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        if (!existing.getUsername().equals(profile.getUsername()) && repository.existsByUsername(profile.getUsername())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username already taken");
+        }
+        existing.setUsername(profile.getUsername());
+        existing.setUid(profile.getUid());
+        existing.setFirstName(profile.getFirstName());
+        existing.setLastName(profile.getLastName());
+        existing.setBirthDate(profile.getBirthDate());
+        existing.setGender(profile.getGender());
+        existing.setNationality(profile.getNationality());
+        existing.setAddress(profile.getAddress());
+        existing.setPhone(profile.getPhone());
+        existing.setLanguage(profile.getLanguage());
+        existing.setInterests(profile.getInterests());
+        return repository.save(existing);
+    }
+
+    @PutMapping("/uid/{uid}")
+    public UserProfile updateByUid(@PathVariable String uid, @RequestBody UserProfile profile) {
+        UserProfile existing = repository.findByUid(uid).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        if (!existing.getUsername().equals(profile.getUsername()) && repository.existsByUsername(profile.getUsername())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username already taken");
+        }
+        existing.setUsername(profile.getUsername());
+        existing.setUid(uid);
+        existing.setFirstName(profile.getFirstName());
+        existing.setLastName(profile.getLastName());
+        existing.setBirthDate(profile.getBirthDate());
+        existing.setGender(profile.getGender());
+        existing.setNationality(profile.getNationality());
+        existing.setAddress(profile.getAddress());
+        existing.setPhone(profile.getPhone());
+        existing.setLanguage(profile.getLanguage());
+        existing.setInterests(profile.getInterests());
+        return repository.save(existing);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/backend/src/main/java/com/example/backend/UserProfileRepository.java
+++ b/backend/src/main/java/com/example/backend/UserProfileRepository.java
@@ -1,0 +1,10 @@
+package com.example.backend;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+    boolean existsByUsername(String username);
+    Optional<UserProfile> findByUid(String uid);
+}

--- a/src/pages/complete-profile/complete-profile.tsx
+++ b/src/pages/complete-profile/complete-profile.tsx
@@ -85,13 +85,9 @@ export const CompleteProfile: React.FC = () => {
           fail(true);
           break;
         }
-        const q = query(
-          collection(db, "userProfiles"),
-          where("profile.username", "==", trimmed),
-          where("uid", "!=", user?.uid || "")
-        );
-        const snap = await getDocs(q);
-        if (!snap.empty) {
+        const resp = await fetch(`http://localhost:8080/api/userProfiles/check?username=${encodeURIComponent(trimmed)}`);
+        const available = await resp.json();
+        if (!available) {
           setFieldErrors(prev => ({ ...prev, [name]: true }));
           setSnackbarMessage("Benutzername bereits vergeben.");
           setSnackbarOpen(true);
@@ -150,6 +146,17 @@ export const CompleteProfile: React.FC = () => {
       },
       { merge: true }
     );
+
+    const resp = await fetch("http://localhost:8080/api/userProfiles", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ uid: user.uid, ...formData })
+    });
+    if (!resp.ok) {
+      setSnackbarMessage("Benutzername bereits vergeben.");
+      setSnackbarOpen(true);
+      return;
+    }
 
     navigate("/");
   };

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -100,13 +100,9 @@ export const Profile: React.FC = () => {
           break;
         }
         if (user) {
-          const q = query(
-            collection(db, "userProfiles"),
-            where("profile.username", "==", trimmed),
-            where("uid", "!=", user.uid)
-          );
-          const snap = await getDocs(q);
-          if (!snap.empty) {
+          const resp = await fetch(`http://localhost:8080/api/userProfiles/check?username=${encodeURIComponent(trimmed)}`);
+          const available = await resp.json();
+          if (!available) {
             setFieldErrors(prev => ({ ...prev, [name]: true }));
             setSnackbarMessage("Benutzername bereits vergeben.");
             setSnackbarOpen(true);
@@ -157,6 +153,17 @@ export const Profile: React.FC = () => {
       },
       { merge: true }
     );
+
+    const resp = await fetch(`http://localhost:8080/api/userProfiles/uid/${auth.currentUser.uid}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ uid: auth.currentUser.uid, ...formData })
+    });
+    if (!resp.ok) {
+      setSnackbarMessage("Benutzername bereits vergeben.");
+      setSnackbarOpen(true);
+      return;
+    }
     setSnackbarMessage("Profil aktualisiert.");
     setSnackbarOpen(true);
   };


### PR DESCRIPTION
## Summary
- add `UserProfile` JPA entity with username field and other profile details
- create a repository and REST controller to manage profiles and check username availability
- integrate profile pages with the backend for username checks and storing data

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*
- `./mvnw test` *(fails: network unreachable when resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68556813e4a48333a61d72639bbe2f30