### PR TITLE
Add profile image upload and display

### DIFF
--- a/src/components/layout/header-elements/quick-menu-buttons.tsx
+++ b/src/components/layout/header-elements/quick-menu-buttons.tsx
@@ -15,7 +15,7 @@ import * as React from "react";
 import {useLocation, useNavigate} from "react-router-dom";
 import {Divider, Fade, ListItemIcon} from "@mui/material";
 import {auth} from "../../../firebase_config";
-import {selectName} from "../../../store/slices/user-profile";
+import {selectName, selectImage} from "../../../store/slices/user-profile";
 import {useSelector} from "react-redux";
 
 export interface AuthenticationButtonsProps {
@@ -29,6 +29,7 @@ export const QuickMenuButtons = (props: AuthenticationButtonsProps) => {
     const location = useLocation();
     const navigate = useNavigate();
     const userName: string = useSelector(selectName);
+    const imageUrl: string | undefined = useSelector(selectImage);
 
     return (
         <>
@@ -37,7 +38,7 @@ export const QuickMenuButtons = (props: AuthenticationButtonsProps) => {
                     <Box sx={{flexGrow: 0}}>
                         {/*<NotificationButton />*/}
                         <IconButton onClick={props.handleOpenUserMenu} sx={{p: 0}}>
-                            <Avatar src=""/>
+                            <Avatar src={imageUrl || ''}/>
                         </IconButton>
                         <Menu
                             sx={{mt: '45px'}}

--- a/src/firebase/firebase-service.ts
+++ b/src/firebase/firebase-service.ts
@@ -1,4 +1,4 @@
-import { auth, googleAuthProvider } from '../firebase_config';
+import { auth, googleAuthProvider, storage } from '../firebase_config';
 import {
     signInWithPopup,
     signOut,
@@ -6,6 +6,7 @@ import {
     signInWithEmailAndPassword,
 
 } from "firebase/auth";
+import { ref, uploadBytes, getDownloadURL, deleteObject } from "firebase/storage";
 
 export const signInWithGoogle = async () => {
     try {
@@ -50,5 +51,28 @@ export const signInWithEmail = async (email: string, password: string) => {
     } catch (error) {
         console.error(error);
         return null;
+    }
+};
+
+export const uploadProfileImage = async (uid: string, file: File): Promise<string | null> => {
+    try {
+        const imageRef = ref(storage, `profile_images/${uid}`);
+        await uploadBytes(imageRef, file);
+        const url = await getDownloadURL(imageRef);
+        return url;
+    } catch (error) {
+        console.error('Error uploading profile image:', error);
+        return null;
+    }
+};
+
+export const deleteProfileImage = async (uid: string): Promise<boolean> => {
+    try {
+        const imageRef = ref(storage, `profile_images/${uid}`);
+        await deleteObject(imageRef);
+        return true;
+    } catch (error) {
+        console.error('Error deleting profile image:', error);
+        return false;
     }
 };

--- a/src/firebase_config.ts
+++ b/src/firebase_config.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from "firebase/app";
 import { getAuth, GoogleAuthProvider } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
+import { getStorage } from "firebase/storage";
 import { getAnalytics } from "firebase/analytics";
 
 const firebaseConfig = {
@@ -21,3 +22,4 @@ getAnalytics(app); // optional
 export const auth = getAuth(app);
 export const googleAuthProvider = new GoogleAuthProvider();
 export const db = getFirestore(app);
+export const storage = getStorage(app);


### PR DESCRIPTION
## Summary
- initialize Firebase storage
- add upload/delete helpers for profile images
- extend user profile slice with image actions & selectors
- support uploading and removing profile pictures in profile pages
- show saved avatar in header quick menu

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68556e68b50c833395805fd0d46d5bda