### PR TITLE
Fix docker compose command in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,5 +36,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Start application stack
         run: |
-          docker-compose pull
-          docker-compose up -d
+          docker compose pull
+          docker compose up -d

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ This repository contains separate frontend and backend applications.
 - **frontend/**: React application built with TypeScript.
 - **backend/**: Spring Boot REST API.
 
-Both components have Dockerfiles and can be orchestrated together with a Postgres database using `docker-compose`.
+Both components have Dockerfiles and can be orchestrated together with a Postgres database using Docker Compose (`docker compose`).
 
 Running all services locally:
 
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
 The backend will automatically connect to the included Postgres container using


### PR DESCRIPTION
## Summary
- fix deploy workflow to use Docker Compose v2 syntax
- update README to use `docker compose`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network unreachable)*
- `npm install --silent` *(fails: package fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_685822b613b08333a35a0a44c479e436