### PR TITLE
Add Jamiah management

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/Jamiah.java
+++ b/backend/src/main/java/com/example/backend/jamiah/Jamiah.java
@@ -1,0 +1,101 @@
+package com.example.backend.jamiah;
+
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "jamiahs")
+public class Jamiah {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private BigDecimal monthlyContribution;
+
+    private Boolean isPublic;
+
+    private Integer maxGroupSize;
+
+    private Integer cycles;
+
+    private BigDecimal rate;
+
+    @Enumerated(EnumType.STRING)
+    private RateInterval rateInterval;
+
+    private LocalDate plannedStartDate;
+
+    public Jamiah() {}
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public BigDecimal getMonthlyContribution() {
+        return monthlyContribution;
+    }
+
+    public void setMonthlyContribution(BigDecimal monthlyContribution) {
+        this.monthlyContribution = monthlyContribution;
+    }
+
+    public Boolean getIsPublic() {
+        return isPublic;
+    }
+
+    public void setIsPublic(Boolean isPublic) {
+        this.isPublic = isPublic;
+    }
+
+    public Integer getMaxGroupSize() {
+        return maxGroupSize;
+    }
+
+    public void setMaxGroupSize(Integer maxGroupSize) {
+        this.maxGroupSize = maxGroupSize;
+    }
+
+    public Integer getCycles() {
+        return cycles;
+    }
+
+    public void setCycles(Integer cycles) {
+        this.cycles = cycles;
+    }
+
+    public BigDecimal getRate() {
+        return rate;
+    }
+
+    public void setRate(BigDecimal rate) {
+        this.rate = rate;
+    }
+
+    public RateInterval getRateInterval() {
+        return rateInterval;
+    }
+
+    public void setRateInterval(RateInterval rateInterval) {
+        this.rateInterval = rateInterval;
+    }
+
+    public LocalDate getPlannedStartDate() {
+        return plannedStartDate;
+    }
+
+    public void setPlannedStartDate(LocalDate plannedStartDate) {
+        this.plannedStartDate = plannedStartDate;
+    }
+}

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
@@ -1,0 +1,54 @@
+package com.example.backend.jamiah;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/jamiahs")
+@CrossOrigin(origins = "*")
+public class JamiahController {
+    private final JamiahRepository repository;
+
+    public JamiahController(JamiahRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping
+    public List<Jamiah> list() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public Jamiah get(@PathVariable Long id) {
+        return repository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Jamiah create(@RequestBody Jamiah jamiah) {
+        return repository.save(jamiah);
+    }
+
+    @PutMapping("/{id}")
+    public Jamiah update(@PathVariable Long id, @RequestBody Jamiah jamiah) {
+        Jamiah existing = repository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        existing.setName(jamiah.getName());
+        existing.setMonthlyContribution(jamiah.getMonthlyContribution());
+        existing.setIsPublic(jamiah.getIsPublic());
+        existing.setMaxGroupSize(jamiah.getMaxGroupSize());
+        existing.setCycles(jamiah.getCycles());
+        existing.setRate(jamiah.getRate());
+        existing.setRateInterval(jamiah.getRateInterval());
+        existing.setPlannedStartDate(jamiah.getPlannedStartDate());
+        return repository.save(existing);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahRepository.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahRepository.java
@@ -1,0 +1,6 @@
+package com.example.backend.jamiah;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JamiahRepository extends JpaRepository<Jamiah, Long> {
+}

--- a/backend/src/main/java/com/example/backend/jamiah/RateInterval.java
+++ b/backend/src/main/java/com/example/backend/jamiah/RateInterval.java
@@ -1,0 +1,6 @@
+package com.example.backend.jamiah;
+
+public enum RateInterval {
+    WEEKLY,
+    MONTHLY
+}

--- a/frontend/src/models/Jamiah.ts
+++ b/frontend/src/models/Jamiah.ts
@@ -1,0 +1,11 @@
+export interface Jamiah {
+  id: number;
+  name: string;
+  monthlyContribution?: number;
+  isPublic?: boolean;
+  maxGroupSize?: number;
+  cycles?: number;
+  rate?: number;
+  rateInterval?: 'WEEKLY' | 'MONTHLY';
+  plannedStartDate?: string;
+}

--- a/frontend/src/pages/groups/groups.tsx
+++ b/frontend/src/pages/groups/groups.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Box,
   Button,
@@ -23,23 +23,27 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import KeyIcon from '@mui/icons-material/VpnKey';
 import PublicIcon from '@mui/icons-material/Public';
 import LockIcon from '@mui/icons-material/Lock';
+import { Jamiah } from '../../models/Jamiah';
 
 export const Groups = () => {
-  const dummyGroups = [
-    { name: 'Jamiah Berlin', members: 34, contribution: '50€/Monat', role: 'Admin', type: 'public' },
-    { name: 'Jamiah München', members: 21, contribution: '40€/Monat', role: 'Mitglied', type: 'private' },
-    { name: 'Jamiah Köln', members: 17, contribution: '35€/Monat', role: 'Admin', type: 'public' },
-  ];
+  const [groups, setGroups] = useState<Jamiah[]>([]);
+  const [openModal, setOpenModal] = useState(false);
+  const [selectedGroup, setSelectedGroup] = useState<Jamiah | null>(null);
+  const [openCreateModal, setOpenCreateModal] = useState(false);
+  const [openJoinModal, setOpenJoinModal] = useState(false);
+  const [newGroup, setNewGroup] = useState<Partial<Jamiah>>({ name: '', monthlyContribution: undefined, isPublic: false });
 
-  const [openModal, setOpenModal] = React.useState(false);
-  const [selectedGroup, setSelectedGroup] = React.useState<typeof dummyGroups[0] | null>(null);
-  const [openCreateModal, setOpenCreateModal] = React.useState(false);
-  const [openJoinModal, setOpenJoinModal] = React.useState(false);
+  useEffect(() => {
+    fetch('http://localhost:8080/api/jamiahs')
+      .then(res => res.json())
+      .then(setGroups)
+      .catch(() => setGroups([]));
+  }, []);
 
   const handleCreateOpen = () => setOpenCreateModal(true);
   const handleJoinOpen = () => setOpenJoinModal(true);
   const handleCloseModal = () => setOpenModal(false);
-  const handleDetails = (group: typeof dummyGroups[0]) => {
+  const handleDetails = (group: Jamiah) => {
     setSelectedGroup(group);
     setOpenModal(true);
   };
@@ -58,14 +62,14 @@ export const Groups = () => {
           </Box>
         </Box>
 
-        {dummyGroups.length === 0 ? (
+        {groups.length === 0 ? (
             <Typography variant="body1" color="textSecondary">
               Du bist noch keiner Jamiah beigetreten. Verwende einen Einladungscode oder gründe deine eigene Jamiah.
             </Typography>
         ) : (
             <Grid container spacing={4}>
-              {dummyGroups.map((group, index) => (
-                  <Grid item xs={12} sm={6} md={4} key={index}>
+              {groups.map((group) => (
+                  <Grid item xs={12} sm={6} md={4} key={group.id}>
                     <Card elevation={3} sx={{ transition: '0.3s', '&:hover': { transform: 'scale(1.02)' } }}>
                       <CardContent>
                         <Box display="flex" justifyContent="space-between" alignItems="center">
@@ -77,9 +81,12 @@ export const Groups = () => {
                           )}
                         </Box>
                         <Divider sx={{ my: 1 }} />
-                        <Typography variant="body2">Mitglieder: <b>{group.members}</b></Typography>
-                        <Typography variant="body2">Beitrag: <b>{group.contribution}</b></Typography>
-                        <Typography variant="body2">Rolle: <b>{group.role}</b></Typography>
+                        {group.maxGroupSize && (
+                          <Typography variant="body2">Max Mitglieder: <b>{group.maxGroupSize}</b></Typography>
+                        )}
+                        {group.monthlyContribution !== undefined && (
+                          <Typography variant="body2">Beitrag: <b>{group.monthlyContribution}€</b></Typography>
+                        )}
                       </CardContent>
                       <CardActions>
                         <Button
@@ -100,44 +107,100 @@ export const Groups = () => {
 
         {/* Detail-Modal */}
         <Dialog open={openModal} onClose={handleCloseModal} maxWidth="sm" fullWidth>
-          <DialogTitle>Details zur Jamiah</DialogTitle>
-          <DialogContent>
-            {selectedGroup && (
-                <>
-                  <Typography variant="h6">{selectedGroup.name}</Typography>
-                  <Typography>Mitglieder: {selectedGroup.members}</Typography>
-                  <Typography>Beitrag: {selectedGroup.contribution}</Typography>
-                  <Typography>Rolle: {selectedGroup.role}</Typography>
-                  <Typography sx={{ mt: 2 }} color="text.secondary">
-                    Weitere Verwaltungsfunktionen folgen hier…
-                  </Typography>
-                </>
-            )}
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={handleCloseModal}>Schließen</Button>
-          </DialogActions>
+          <DialogTitle>Jamiah bearbeiten</DialogTitle>
+          {selectedGroup && (
+            <>
+              <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <TextField
+                  label="Name"
+                  value={selectedGroup.name}
+                  onChange={e => setSelectedGroup({ ...selectedGroup, name: e.target.value })}
+                />
+                <TextField
+                  label="Monatlicher Beitrag (€)"
+                  type="number"
+                  value={selectedGroup.monthlyContribution ?? ''}
+                  onChange={e => setSelectedGroup({ ...selectedGroup, monthlyContribution: Number(e.target.value) })}
+                  InputProps={{ endAdornment: <InputAdornment position="end">€</InputAdornment> }}
+                />
+                <TextField
+                  select
+                  label="Typ"
+                  value={selectedGroup.isPublic ? 'public' : 'private'}
+                  onChange={e => setSelectedGroup({ ...selectedGroup, isPublic: e.target.value === 'public' })}
+                >
+                  <MenuItem value="private">Privat (nur mit Einladung)</MenuItem>
+                  <MenuItem value="public">Öffentlich (sichtbar für alle)</MenuItem>
+                </TextField>
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={handleCloseModal}>Abbrechen</Button>
+                <Button
+                  onClick={() => {
+                    fetch(`http://localhost:8080/api/jamiahs/${selectedGroup.id}`, {
+                      method: 'PUT',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify(selectedGroup)
+                    }).then(() => {
+                      setGroups(groups.map(g => (g.id === selectedGroup.id ? selectedGroup : g)));
+                      setOpenModal(false);
+                    });
+                  }}
+                >
+                  Speichern
+                </Button>
+              </DialogActions>
+            </>
+          )}
         </Dialog>
 
         {/* Create Modal */}
         <Dialog open={openCreateModal} onClose={() => setOpenCreateModal(false)} maxWidth="sm" fullWidth>
           <DialogTitle>Neue Jamiah gründen</DialogTitle>
           <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-            <TextField label="Name der Jamiah" fullWidth />
-            <TextField label="Monatlicher Beitrag (€)" type="number" fullWidth InputProps={{
-              endAdornment: <InputAdornment position="end">€</InputAdornment>,
-            }} />
-            <TextField select label="Typ" defaultValue="private">
+            <TextField
+              label="Name der Jamiah"
+              fullWidth
+              value={newGroup.name}
+              onChange={e => setNewGroup({ ...newGroup, name: e.target.value })}
+            />
+            <TextField
+              label="Monatlicher Beitrag (€)"
+              type="number"
+              fullWidth
+              value={newGroup.monthlyContribution ?? ''}
+              onChange={e => setNewGroup({ ...newGroup, monthlyContribution: Number(e.target.value) })}
+              InputProps={{ endAdornment: <InputAdornment position="end">€</InputAdornment> }}
+            />
+            <TextField
+              select
+              label="Typ"
+              value={newGroup.isPublic ? 'public' : 'private'}
+              onChange={e => setNewGroup({ ...newGroup, isPublic: e.target.value === 'public' })}
+            >
               <MenuItem value="private">Privat (nur mit Einladung)</MenuItem>
               <MenuItem value="public">Öffentlich (sichtbar für alle)</MenuItem>
             </TextField>
           </DialogContent>
           <DialogActions>
             <Button onClick={() => setOpenCreateModal(false)}>Abbrechen</Button>
-            <Button onClick={() => {
-              alert('Jamiah gespeichert!');
-              setOpenCreateModal(false);
-            }}>Erstellen</Button>
+            <Button
+              onClick={() => {
+                fetch('http://localhost:8080/api/jamiahs', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify(newGroup)
+                })
+                  .then(res => res.json())
+                  .then(j => {
+                    setGroups([...groups, j]);
+                    setOpenCreateModal(false);
+                    setNewGroup({ name: '', monthlyContribution: undefined, isPublic: false });
+                  });
+              }}
+            >
+              Erstellen
+            </Button>
           </DialogActions>
         </Dialog>
 


### PR DESCRIPTION
## Summary
- implement Jamiah JPA entity with controller and repository
- add RateInterval enum for payment rhythm
- expose `/api/jamiahs` endpoints for CRUD operations
- display Jamiahs from backend on groups page and allow creation/editing
- add Jamiah model to frontend

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685826ad417c83338fe4c8b8e46b683c