### PR TITLE
Fix Cloud Run workflow deployment flags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,16 +57,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@v1
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
       - name: Set up gcloud SDK
         uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ secrets.GCP_PROJECT }}
-          export_default_credentials: true
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
 
       - name: Configure Docker for GCR
         run: |
@@ -98,11 +93,12 @@ jobs:
           region: europe-west3
           image: gcr.io/${{ secrets.GCP_PROJECT }}/mansa-backend:latest
           project_id: ${{ secrets.GCP_PROJECT }}
-          platform: managed
-          allow_unauthenticated: true
           env_vars: |
             SPRING_DATASOURCE_URL="jdbc:mysql://google/mansa?cloudSqlInstance=${{ secrets.GCP_PROJECT }}:europe-west3:mansa-db&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=false"
           secrets: |
             SPRING_DATASOURCE_USERNAME=projects/${{ secrets.GCP_PROJECT }}/secrets/SPRING_DATASOURCE_USERNAME:latest,
             SPRING_DATASOURCE_PASSWORD=projects/${{ secrets.GCP_PROJECT }}/secrets/SPRING_DATASOURCE_PASSWORD:latest
-          cloudsql_instances: ${{ secrets.GCP_PROJECT }}:europe-west3:mansa-db
+          flags: |
+            --platform=managed
+            --allow-unauthenticated
+            --add-cloudsql-instances=${{ secrets.GCP_PROJECT }}:europe-west3:mansa-db


### PR DESCRIPTION
## Summary
- update Cloud Run deploy step
- switch gcloud setup to use service account key

## Testing
- `./mvnw -q test` *(fails: could not resolve spring dependencies)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686104bd776883338dd161bf2a28dd9b