### PR TITLE
Fix GCR docker push auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,12 +60,12 @@ jobs:
       - name: Set up gcloud SDK
         uses: google-github-actions/setup-gcloud@v1
         with:
-          project_id: ${{ secrets.GCP_PROJECT }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT }}
+          export_default_credentials: true
 
       - name: Configure Docker for GCR
-        run: |
-          gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker --quiet
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
- fix Google Cloud auth for docker pushes

## Testing
- `./mvnw -B test` *(fails: Could not transfer artifact)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861120bd81483338bed5b0b058dc624