### PR TITLE
Add GCP Cloud SQL starter and update configuration

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -46,6 +46,11 @@
       <version>1.25.1</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-gcp-starter-sql-mysql</artifactId>
+    </dependency>
+
     <!-- Testing -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,14 +1,10 @@
 spring.application.name=backend
 
-# Cloud SQL Socket-Factory Konfiguration
-spring.datasource.url=jdbc:mysql://google/${DB_NAME}?cloudSqlInstance=${INSTANCE_CONNECTION_NAME}&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=false
-
-# Credentials aus Cloud Run Environment
+spring.cloud.gcp.sql.instance-connection-name=${GCP_PROJECT}:europe-west3:mansa-db
+spring.cloud.gcp.sql.database-name=mansa
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
-
-# (optional) Expliziter Treiber
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+server.port=${PORT:8080}
 
 # JPA/Hibernate Einstellungen
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## Summary
- include Spring Cloud GCP Cloud SQL starter in backend
- configure Cloud SQL properties in `application.properties`

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68614a6730248333b4e1d5f0d66cbc30