### PR TITLE
Update Spring Cloud GCP BOM

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -28,7 +28,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>5.0.2</version>
+        <version>5.2.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -46,23 +46,9 @@
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
 
-    <!-- MySQL JDBC Driver -->
-    <dependency>
-      <groupId>com.mysql</groupId>
-      <artifactId>mysql-connector-j</artifactId>
-    </dependency>
-
-    <!-- Cloud SQL Socket Factory for MySQL Connector/J 8.x -->
-    <dependency>
-      <groupId>com.google.cloud.sql</groupId>
-      <artifactId>mysql-socket-factory-connector-j-8</artifactId>
-      <version>1.25.1</version>
-    </dependency>
-
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-gcp-starter-sql-mysql</artifactId>
-      <version>1.2.8.RELEASE</version>
     </dependency>
 
     <!-- Testing -->


### PR DESCRIPTION
## Summary
- bump Spring Cloud GCP BOM to 5.2.0
- rely on `spring-cloud-gcp-starter-sql-mysql` for MySQL connectivity

## Testing
- `mvn test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686196673a3c833387d204c6d54f10ce