### PR TITLE
Add validation starter

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -46,6 +46,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
 
     <!-- Flyway for database migrations -->
     <dependency>


### PR DESCRIPTION
## Summary
- fix compilation by adding `spring-boot-starter-validation` to backend dependencies

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6862507ded0083338f7e4c414d142275