### PR TITLE
Fix Flyway MySQL support

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -56,6 +56,11 @@
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
     </dependency>
+    <!-- Add MySQL support for Flyway -->
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-mysql</artifactId>
+    </dependency>
 
     <!-- Lombok for boilerplate reduction -->
     <dependency>


### PR DESCRIPTION
## Summary
- add `flyway-mysql` to backend dependencies to support MySQL 8

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686259a696a0833396ee580f4f5fb5e9