### PR TITLE
Fix API base URL for compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Damit werden drei Container gestartet:
 2. **frontend** – React-App ausgeliefert durch nginx auf Port 3000
 3. **db** – MySQL 8 mit dem Schema `mansa`
 
+Das Compose-Setup setzt die Umgebungsvariable `REACT_APP_BACKEND_URL` im
+Frontend-Container auf `http://backend:8080`, sodass API-Aufrufe korrekt an die
+Backend-Service-Adresse geleitet werden.
+
 Zugangsdaten für die Datenbank sind in `docker-compose.yml` hinterlegt und können per Umgebungsvariablen überschrieben werden.
 
 ## Cloud Architektur

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     build: ./frontend
     ports:
       - "3000:80"
+    environment:
+      - REACT_APP_BACKEND_URL=http://backend:8080
     depends_on:
       - backend
   db:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -12,4 +12,5 @@ REACT_APP_OPENAI_API_KEY=
 
 # Backend service base URL
 REACT_APP_BACKEND_URL=http://localhost:8080
+# When running via docker compose this value is overridden to http://backend:8080
 


### PR DESCRIPTION
## Summary
- set REACT_APP_BACKEND_URL for frontend container
- document compose variable in README
- update .env.example comment

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6862e8140b888333909cb334884d3f61