### PR TITLE
Add Jamiah invitation features

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import {Documents} from "./pages/documents/documents";
 import {Reports} from "./pages/reports/reports";
 import {Members} from "./pages/memebers/members";
 import {Onboarding} from "./pages/onboarding/onboarding";
+import { JoinJamiahPage } from "./pages/join-jamiah/join-jamiah";
 import {VerifyEmail} from "./pages/authentication/verifyEmail";
 import {HelloBackend} from "./pages/hello-backend/hello-backend";
 
@@ -60,6 +61,7 @@ function App() {
                 <Route path={`/${ROUTES.MY_RISKS}`} element={<PrivateRoute><MyRisks /></PrivateRoute>} />
                 <Route path={`/${ROUTES.MY_BIDS}`} element={<PrivateRoute><MyBids /></PrivateRoute>} />
                 <Route path={`/${ROUTES.ONBOARDING}`} element={<PrivateRoute><Onboarding /></PrivateRoute>} />
+                <Route path={`/${ROUTES.JOIN_JAMIAH}`} element={<PrivateRoute><JoinJamiahPage /></PrivateRoute>} />
 
 
                 {/* Public routes */}

--- a/frontend/src/components/jamiah/GenerateInviteButton.tsx
+++ b/frontend/src/components/jamiah/GenerateInviteButton.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { Button } from '@mui/material';
+import KeyIcon from '@mui/icons-material/VpnKey';
+import { API_BASE_URL } from '../../constants/api';
+import { InviteCodeDialog } from './InviteCodeDialog';
+
+interface GenerateInviteButtonProps {
+  jamiahId: string | number;
+}
+
+export const GenerateInviteButton: React.FC<GenerateInviteButtonProps> = ({ jamiahId }) => {
+  const [open, setOpen] = useState(false);
+  const [code, setCode] = useState<string | null>(null);
+
+  const handleClick = () => {
+    fetch(`${API_BASE_URL}/api/jamiahs/${jamiahId}/invitation`, { method: 'POST' })
+      .then(res => res.text())
+      .then(setCode)
+      .catch(() => setCode('Fehler'))
+      .finally(() => setOpen(true));
+  };
+
+  return (
+    <>
+      <Button size="small" variant="outlined" fullWidth startIcon={<KeyIcon />} onClick={handleClick}>
+        Einladungscode
+      </Button>
+      <InviteCodeDialog open={open} code={code} onClose={() => setOpen(false)} />
+    </>
+  );
+};

--- a/frontend/src/components/jamiah/InviteCodeDialog.tsx
+++ b/frontend/src/components/jamiah/InviteCodeDialog.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material';
+
+interface InviteCodeDialogProps {
+  open: boolean;
+  code: string | null;
+  onClose: () => void;
+}
+
+export const InviteCodeDialog: React.FC<InviteCodeDialogProps> = ({ open, code, onClose }) => (
+  <Dialog open={open} onClose={onClose}>
+    <DialogTitle>Einladungscode</DialogTitle>
+    <DialogContent>
+      <Typography variant="h5" align="center" sx={{ wordBreak: 'break-all' }}>
+        {code ?? '...'}
+      </Typography>
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={onClose}>Schließen</Button>
+    </DialogActions>
+  </Dialog>
+);

--- a/frontend/src/pages/groups/groups.tsx
+++ b/frontend/src/pages/groups/groups.tsx
@@ -25,13 +25,15 @@ import PublicIcon from '@mui/icons-material/Public';
 import LockIcon from '@mui/icons-material/Lock';
 import { Jamiah } from '../../models/Jamiah';
 import { API_BASE_URL } from '../../constants/api';
+import { GenerateInviteButton } from '../../components/jamiah/GenerateInviteButton';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '../../routing/routes';
 
 export const Groups = () => {
   const [groups, setGroups] = useState<Jamiah[]>([]);
   const [openModal, setOpenModal] = useState(false);
   const [selectedGroup, setSelectedGroup] = useState<Jamiah | null>(null);
   const [openCreateModal, setOpenCreateModal] = useState(false);
-  const [openJoinModal, setOpenJoinModal] = useState(false);
   const [newGroup, setNewGroup] = useState<Partial<Jamiah>>({
     name: '',
     monthlyContribution: undefined,
@@ -50,8 +52,9 @@ export const Groups = () => {
       .catch(() => setGroups([]));
   }, []);
 
+  const navigate = useNavigate();
   const handleCreateOpen = () => setOpenCreateModal(true);
-  const handleJoinOpen = () => setOpenJoinModal(true);
+  const handleJoinOpen = () => navigate(`/${ROUTES.JOIN_JAMIAH}`);
   const handleCloseModal = () => setOpenModal(false);
   const handleDetails = (group: Jamiah) => {
     setSelectedGroup(group);
@@ -98,7 +101,7 @@ export const Groups = () => {
                           <Typography variant="body2">Beitrag: <b>{group.monthlyContribution}€</b></Typography>
                         )}
                       </CardContent>
-                      <CardActions>
+                      <CardActions sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
                         <Button
                             size="small"
                             variant="outlined"
@@ -108,6 +111,9 @@ export const Groups = () => {
                         >
                           Details ansehen
                         </Button>
+                        {!group.isPublic && group.id && (
+                            <GenerateInviteButton jamiahId={group.id} />
+                        )}
                       </CardActions>
                     </Card>
                   </Grid>
@@ -177,8 +183,11 @@ export const Groups = () => {
                   <MenuItem value="public">Öffentlich (sichtbar für alle)</MenuItem>
                 </TextField>
               </DialogContent>
-              <DialogActions>
+              <DialogActions sx={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch', gap: 1 }}>
                 <Button onClick={handleCloseModal}>Abbrechen</Button>
+                {!selectedGroup.isPublic && selectedGroup.id && (
+                  <GenerateInviteButton jamiahId={selectedGroup.id} />
+                )}
                 <Button
                   onClick={() => {
                     fetch(`${API_BASE_URL}/api/jamiahs/${selectedGroup.id}`, {
@@ -295,20 +304,6 @@ export const Groups = () => {
           </DialogActions>
         </Dialog>
 
-        {/* Join Modal */}
-        <Dialog open={openJoinModal} onClose={() => setOpenJoinModal(false)} maxWidth="xs" fullWidth>
-          <DialogTitle>Jamiah beitreten</DialogTitle>
-          <DialogContent sx={{ mt: 1 }}>
-            <TextField label="Einladungscode" fullWidth />
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setOpenJoinModal(false)}>Abbrechen</Button>
-            <Button onClick={() => {
-              alert('Beitrittsanfrage gesendet!');
-              setOpenJoinModal(false);
-            }}>Beitreten</Button>
-          </DialogActions>
-        </Dialog>
       </Box>
   );
 };

--- a/frontend/src/pages/join-jamiah/join-jamiah.tsx
+++ b/frontend/src/pages/join-jamiah/join-jamiah.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { Box, Button, TextField, Typography, Snackbar, Alert } from '@mui/material';
+import { API_BASE_URL } from '../../constants/api';
+
+export const JoinJamiahPage = () => {
+  const [code, setCode] = useState('');
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState(false);
+
+  const handleSubmit = () => {
+    fetch(`${API_BASE_URL}/api/jamiahs/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code })
+    })
+      .then(res => {
+        if (res.ok) {
+          setMessage('Beitritt erfolgreich angefragt.');
+          setError(false);
+        } else {
+          setMessage('Einladungscode ungültig.');
+          setError(true);
+        }
+      })
+      .catch(() => {
+        setMessage('Einladungscode ungültig.');
+        setError(true);
+      })
+      .finally(() => setOpen(true));
+  };
+
+  return (
+    <Box p={4} maxWidth={400} mx="auto">
+      <Typography variant="h5" gutterBottom>
+        Jamiah beitreten
+      </Typography>
+      <TextField
+        label="Einladungscode"
+        fullWidth
+        value={code}
+        onChange={e => setCode(e.target.value)}
+        sx={{ mb: 2 }}
+      />
+      <Button variant="contained" fullWidth onClick={handleSubmit} disabled={!code}>
+        Beitreten
+      </Button>
+      <Snackbar open={open} autoHideDuration={6000} onClose={() => setOpen(false)}>
+        <Alert severity={error ? 'error' : 'success'} onClose={() => setOpen(false)} sx={{ width: '100%' }}>
+          {message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+};

--- a/frontend/src/routing/routes.ts
+++ b/frontend/src/routing/routes.ts
@@ -26,6 +26,8 @@ export const ROUTES = {
     ONBOARDING: 'onboarding',
     COMPLETE_PROFILE: 'complete-profile',
 
+    JOIN_JAMIAH: 'join-jamiah',
+
     HELLO_BACKEND: 'hello-backend',
 
 };


### PR DESCRIPTION
## Summary
- add `JOIN_JAMIAH` route constant
- implement JoinJamiahPage for entering invitation codes
- create components to generate and display invitation codes
- enhance Groups page with invite button and navigation to Join page
- register new page route in App routing

## Testing
- `npm test --silent --runTestsByPath non-existing` *(fails: react-scripts not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6863c64281988333a5364c9584c30609