### PR TITLE
Fix invitation route in frontend

### DIFF
--- a/frontend/src/components/jamiah/GenerateInviteButton.tsx
+++ b/frontend/src/components/jamiah/GenerateInviteButton.tsx
@@ -13,7 +13,7 @@ export const GenerateInviteButton: React.FC<GenerateInviteButtonProps> = ({ jami
   const [code, setCode] = useState<string | null>(null);
 
   const handleClick = () => {
-    fetch(`${API_BASE_URL}/api/jamiahs/${jamiahId}/invitation`, { method: 'POST' })
+    fetch(`${API_BASE_URL}/api/jamiahs/${jamiahId}/invite`, { method: 'POST' })
       .then(res => res.text())
       .then(setCode)
       .catch(() => setCode('Fehler'))


### PR DESCRIPTION
## Summary
- correct invitation fetch URL to `/invite`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6863ced9e3d083339166d5404c4af699