### PR TITLE
Fix invite generation with UUID ids

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
@@ -31,12 +31,12 @@ public class JamiahController {
     }
 
     @PutMapping("/{id}")
-    public JamiahDto update(@PathVariable Long id, @Valid @RequestBody JamiahDto dto) {
+    public JamiahDto update(@PathVariable String id, @Valid @RequestBody JamiahDto dto) {
         return service.update(id, dto);
     }
 
     @PostMapping("/{id}/invite")
-    public JamiahDto invite(@PathVariable Long id) {
+    public JamiahDto invite(@PathVariable String id) {
         return service.createOrRefreshInvitation(id);
     }
 


### PR DESCRIPTION
## Summary
- update JamiahController to accept String IDs
- add helper in JamiahService for lookups by UUID
- support update and invite endpoints using the public UUID

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863d35075148333a3f423fe15107d62