### PR TITLE
Implement group detail view

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
@@ -24,6 +24,11 @@ public class JamiahController {
         return service.findAll();
     }
 
+    @GetMapping("/{id}")
+    public JamiahDto get(@PathVariable String id) {
+        return service.findByPublicId(id);
+    }
+
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public JamiahDto create(@Valid @RequestBody JamiahDto dto) {

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
@@ -90,6 +90,11 @@ public class JamiahService {
         return mapper.toDto(repository.save(entity));
     }
 
+    public JamiahDto findByPublicId(String publicId) {
+        Jamiah entity = getByPublicId(publicId);
+        return mapper.toDto(entity);
+    }
+
     public JamiahDto joinByInvitation(String code) {
         log.info("Join attempt with code {}", code);
         if (isRateLimited(code)) {

--- a/backend/src/test/java/com/example/backend/jamiah/JamiahControllerTest.java
+++ b/backend/src/test/java/com/example/backend/jamiah/JamiahControllerTest.java
@@ -16,6 +16,7 @@ import com.example.backend.jamiah.JamiahRepository;
 import com.example.backend.jamiah.Jamiah;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -123,5 +124,26 @@ class JamiahControllerTest {
     void joinJamiahInvalid() throws Exception {
         mockMvc.perform(post("/api/jamiahs/join?code=INVALID"))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getJamiahById() throws Exception {
+        JamiahDto dto = new JamiahDto();
+        dto.setName("Detail");
+        dto.setIsPublic(true);
+        dto.setMaxGroupSize(3);
+        dto.setCycleCount(2);
+        dto.setRateAmount(new BigDecimal("5"));
+        dto.setRateInterval(RateInterval.MONTHLY);
+        dto.setStartDate(LocalDate.now());
+
+        String response = mockMvc.perform(post("/api/jamiahs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andReturn().getResponse().getContentAsString();
+        JamiahDto created = objectMapper.readValue(response, JamiahDto.class);
+
+        mockMvc.perform(get("/api/jamiahs/" + created.getId()))
+                .andExpect(status().isOk());
     }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,7 @@ import {Reports} from "./pages/reports/reports";
 import {Members} from "./pages/memebers/members";
 import {Onboarding} from "./pages/onboarding/onboarding";
 import { JoinJamiahPage } from "./pages/join-jamiah/join-jamiah";
+import { GroupDetails } from "./pages/group-details/group-details";
 import {VerifyEmail} from "./pages/authentication/verifyEmail";
 import {HelloBackend} from "./pages/hello-backend/hello-backend";
 
@@ -62,6 +63,7 @@ function App() {
                 <Route path={`/${ROUTES.MY_BIDS}`} element={<PrivateRoute><MyBids /></PrivateRoute>} />
                 <Route path={`/${ROUTES.ONBOARDING}`} element={<PrivateRoute><Onboarding /></PrivateRoute>} />
                 <Route path={`/${ROUTES.JOIN_JAMIAH}`} element={<PrivateRoute><JoinJamiahPage /></PrivateRoute>} />
+                <Route path={`/${ROUTES.GROUP_DETAILS}/:id`} element={<PrivateRoute><GroupDetails /></PrivateRoute>} />
 
 
                 {/* Public routes */}

--- a/frontend/src/models/Jamiah.ts
+++ b/frontend/src/models/Jamiah.ts
@@ -1,6 +1,8 @@
 export interface Jamiah {
   id?: string;
   name: string;
+  description?: string;
+  language?: string;
   monthlyContribution?: number;
   isPublic: boolean;
   maxGroupSize?: number;

--- a/frontend/src/pages/group-details/group-details.tsx
+++ b/frontend/src/pages/group-details/group-details.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Box, Typography, Button, Divider } from '@mui/material';
+import { Jamiah } from '../../models/Jamiah';
+import { API_BASE_URL } from '../../constants/api';
+import { ROUTES } from '../../routing/routes';
+
+export const GroupDetails = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [group, setGroup] = useState<Jamiah | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`${API_BASE_URL}/api/jamiahs/${id}`)
+      .then(res => res.json())
+      .then(setGroup)
+      .catch(() => setGroup(null));
+  }, [id]);
+
+  return (
+    <Box p={4} maxWidth={600} mx="auto">
+      <Button variant="text" onClick={() => navigate(`/${ROUTES.GROUPS}`)}>
+        Zurück zur Übersicht
+      </Button>
+      {group ? (
+        <Box mt={2}>
+          <Typography variant="h4" gutterBottom>{group.name}</Typography>
+          {group.description && (
+            <Typography variant="body1" gutterBottom>{group.description}</Typography>
+          )}
+          <Divider sx={{ my: 2 }} />
+          {group.language && (
+            <Typography variant="body2">Sprache: <b>{group.language}</b></Typography>
+          )}
+          {group.maxGroupSize !== undefined && (
+            <Typography variant="body2">Gruppengröße: <b>{group.maxGroupSize}</b></Typography>
+          )}
+          {group.rateAmount !== undefined && (
+            <Typography variant="body2">Ratenhöhe: <b>{group.rateAmount}€</b></Typography>
+          )}
+          {group.rateInterval && (
+            <Typography variant="body2">Ratenrhythmus: <b>{group.rateInterval === 'MONTHLY' ? 'Monatlich' : 'Wöchentlich'}</b></Typography>
+          )}
+          {group.cycleCount !== undefined && (
+            <Typography variant="body2">Laufzeit: <b>{group.cycleCount} {group.rateInterval === 'MONTHLY' ? 'Monate' : 'Wochen'}</b></Typography>
+          )}
+          <Typography variant="body2" mt={2}>
+            Sichtbarkeit: <b>{group.isPublic ? 'Öffentlich' : 'Privat'}</b>
+          </Typography>
+          <Box mt={3}>
+            {group.isPublic ? (
+              <Button variant="contained">Jetzt bewerben</Button>
+            ) : (
+              <Typography color="textSecondary">Beitritt nur per Einladung</Typography>
+            )}
+          </Box>
+        </Box>
+      ) : (
+        <Typography>Gruppe nicht gefunden.</Typography>
+      )}
+    </Box>
+  );
+};

--- a/frontend/src/routing/routes.ts
+++ b/frontend/src/routing/routes.ts
@@ -28,6 +28,8 @@ export const ROUTES = {
 
     JOIN_JAMIAH: 'join-jamiah',
 
+    GROUP_DETAILS: 'group-details',
+
     HELLO_BACKEND: 'hello-backend',
 
 };


### PR DESCRIPTION
## Summary
- expose new GET endpoint to retrieve a single Jamiah by public id
- add JamiahService method `findByPublicId`
- test fetching a Jamiah via the new endpoint
- extend `Jamiah` frontend model with description and language
- add route constant and view for group details
- hook up new route in `App.tsx`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644d37b4948333b9043fab127ca49e