### PR TITLE
Fix invitation copy and add expiry countdown

### DIFF
--- a/frontend/src/components/jamiah/GenerateInviteButton.tsx
+++ b/frontend/src/components/jamiah/GenerateInviteButton.tsx
@@ -10,13 +10,13 @@ interface GenerateInviteButtonProps {
 
 export const GenerateInviteButton: React.FC<GenerateInviteButtonProps> = ({ jamiahId }) => {
   const [open, setOpen] = useState(false);
-  const [code, setCode] = useState<string | null>(null);
+  const [invite, setInvite] = useState<{ invitationCode: string; invitationExpiry: string } | null>(null);
 
   const handleClick = () => {
     fetch(`${API_BASE_URL}/api/jamiahs/${jamiahId}/invite`, { method: 'POST' })
-      .then(res => res.text())
-      .then(setCode)
-      .catch(() => setCode('Fehler'))
+      .then(res => res.json())
+      .then(data => setInvite({ invitationCode: data.invitationCode, invitationExpiry: data.invitationExpiry }))
+      .catch(() => setInvite({ invitationCode: 'Fehler', invitationExpiry: new Date().toISOString() }))
       .finally(() => setOpen(true));
   };
 
@@ -25,7 +25,12 @@ export const GenerateInviteButton: React.FC<GenerateInviteButtonProps> = ({ jami
       <Button size="small" variant="outlined" fullWidth startIcon={<KeyIcon />} onClick={handleClick}>
         Einladungscode
       </Button>
-      <InviteCodeDialog open={open} code={code} onClose={() => setOpen(false)} />
+      <InviteCodeDialog
+        open={open}
+        code={invite?.invitationCode ?? null}
+        expiry={invite?.invitationExpiry ?? null}
+        onClose={() => setOpen(false)}
+      />
     </>
   );
 };

--- a/frontend/src/components/jamiah/InviteCodeDialog.tsx
+++ b/frontend/src/components/jamiah/InviteCodeDialog.tsx
@@ -5,10 +5,31 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 interface InviteCodeDialogProps {
   open: boolean;
   code: string | null;
+  expiry: string | null;
   onClose: () => void;
 }
 
-export const InviteCodeDialog: React.FC<InviteCodeDialogProps> = ({ open, code, onClose }) => {
+export const InviteCodeDialog: React.FC<InviteCodeDialogProps> = ({ open, code, expiry, onClose }) => {
+  const [remaining, setRemaining] = React.useState<number>(0);
+
+  React.useEffect(() => {
+    if (!expiry) return;
+    const target = new Date(expiry).getTime();
+    const update = () => setRemaining(target - Date.now());
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [expiry]);
+
+  const format = (ms: number) => {
+    if (ms <= 0) return '00:00:00';
+    const totalSeconds = Math.floor(ms / 1000);
+    const hours = String(Math.floor(totalSeconds / 3600)).padStart(2, '0');
+    const minutes = String(Math.floor((totalSeconds % 3600) / 60)).padStart(2, '0');
+    const seconds = String(totalSeconds % 60).padStart(2, '0');
+    return `${hours}:${minutes}:${seconds}`;
+  };
+
   const handleCopy = () => {
     if (code) {
       navigator.clipboard.writeText(code);
@@ -28,6 +49,11 @@ export const InviteCodeDialog: React.FC<InviteCodeDialogProps> = ({ open, code, 
               <ContentCopyIcon fontSize="small" />
             </IconButton>
           </Tooltip>
+        )}
+        {expiry && (
+          <Typography variant="body2" color="textSecondary" sx={{ mt: 1 }}>
+            Läuft ab in: {format(remaining)}
+          </Typography>
         )}
       </DialogContent>
       <DialogActions>


### PR DESCRIPTION
## Summary
- handle JSON response for invitation creation
- show invitation code only
- display expiry countdown in invite dialog

## Testing
- `./backend/mvnw -q test` *(fails: Non-resolvable parent POM)*
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644e0451fc8333bb8bd71c9e8dd900