### PR TITLE
Fix Jamiah dropdown widths

### DIFF
--- a/frontend/src/pages/groups/groups.tsx
+++ b/frontend/src/pages/groups/groups.tsx
@@ -155,6 +155,7 @@ export const Groups = () => {
             label="Alle / Öffentliche / Private Jamiahs"
             value={visibilityFilter}
             onChange={e => setVisibilityFilter(e.target.value as 'all' | 'public' | 'private')}
+            sx={{ minWidth: 280 }}
           >
             <MenuItem value="all">Alle</MenuItem>
             <MenuItem value="public">Öffentliche</MenuItem>
@@ -165,6 +166,7 @@ export const Groups = () => {
             label="Aktiver Zyklus / Abgeschlossen"
             value={statusFilter}
             onChange={e => setStatusFilter(e.target.value as 'all' | 'active' | 'completed')}
+            sx={{ minWidth: 280 }}
           >
             <MenuItem value="all">Alle</MenuItem>
             <MenuItem value="active">Aktiver Zyklus</MenuItem>


### PR DESCRIPTION
## Summary
- make dropdown filters in Jamiah group view wide enough to display labels

## Testing
- `npm test --silent` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686467031f84833383d4b2d4b2047abf