### PR TITLE
Implement member limits and counts

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/Jamiah.java
+++ b/backend/src/main/java/com/example/backend/jamiah/Jamiah.java
@@ -6,6 +6,8 @@ import lombok.Data;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
 
 @Data
 @Entity
@@ -31,6 +33,9 @@ public class Jamiah {
     private Integer maxGroupSize;
 
     @Min(1)
+    private Integer maxMembers;
+
+    @Min(1)
     private Integer cycleCount;
 
     @Positive
@@ -46,4 +51,10 @@ public class Jamiah {
     private String invitationCode;
 
     private LocalDate invitationExpiry;
+
+    @ManyToMany
+    @JoinTable(name = "jamiah_members",
+            joinColumns = @JoinColumn(name = "jamiah_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_profile_id"))
+    private Set<com.example.backend.UserProfile> members = new HashSet<>();
 }

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
@@ -46,8 +46,8 @@ public class JamiahController {
     }
 
     @PostMapping("/join")
-    public JamiahDto join(@RequestParam String code) {
-        return service.joinByInvitation(code);
+    public JamiahDto join(@RequestParam String code, @RequestParam String uid) {
+        return service.joinByInvitation(code, uid);
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahMapper.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahMapper.java
@@ -6,9 +6,11 @@ import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface JamiahMapper {
+    @Mapping(target = "currentMembers", expression = "java(jamiah.getMembers() == null ? 0 : jamiah.getMembers().size())")
     JamiahDto toDto(Jamiah jamiah);
 
     @Mapping(target = "id", ignore = true)
+    @Mapping(target = "members", ignore = true)
     Jamiah toEntity(JamiahDto dto);
 
     /**

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahRepository.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahRepository.java
@@ -1,9 +1,17 @@
 package com.example.backend.jamiah;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface JamiahRepository extends JpaRepository<Jamiah, Long> {
     Optional<Jamiah> findByInvitationCode(String invitationCode);
+
+    @Query("select j from Jamiah j left join fetch j.members where j.invitationCode = :code")
+    Optional<Jamiah> findWithMembersByInvitationCode(@Param("code") String invitationCode);
+
+    @Query("select count(m) from Jamiah j join j.members m where j.id = :id")
+    long countMembers(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/example/backend/jamiah/dto/JamiahDto.java
+++ b/backend/src/main/java/com/example/backend/jamiah/dto/JamiahDto.java
@@ -26,6 +26,10 @@ public class JamiahDto {
     @Min(2)
     private Integer maxGroupSize;
 
+    private Integer maxMembers;
+
+    private Integer currentMembers;
+
     @Min(1)
     private Integer cycleCount;
 

--- a/backend/src/main/resources/db/migration/V6__add_membership_table.sql
+++ b/backend/src/main/resources/db/migration/V6__add_membership_table.sql
@@ -1,0 +1,10 @@
+ALTER TABLE jamiah
+    ADD COLUMN max_members INT;
+
+CREATE TABLE jamiah_members (
+    jamiah_id BIGINT NOT NULL,
+    user_profile_id BIGINT NOT NULL,
+    PRIMARY KEY (jamiah_id, user_profile_id),
+    CONSTRAINT fk_jamiah FOREIGN KEY (jamiah_id) REFERENCES jamiah(id),
+    CONSTRAINT fk_user_profile FOREIGN KEY (user_profile_id) REFERENCES user_profiles(id)
+);

--- a/backend/src/test/java/com/example/backend/jamiah/JamiahServiceTest.java
+++ b/backend/src/test/java/com/example/backend/jamiah/JamiahServiceTest.java
@@ -6,6 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.web.server.ResponseStatusException;
+import com.example.backend.UserProfile;
+import com.example.backend.UserProfileRepository;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -24,6 +26,9 @@ class JamiahServiceTest {
 
     @Autowired
     private JamiahRepository repository;
+
+    @Autowired
+    private UserProfileRepository userRepository;
 
     @Test
     void createValidJamiah() {
@@ -65,10 +70,14 @@ class JamiahServiceTest {
         dto.setRateInterval(RateInterval.MONTHLY);
         dto.setStartDate(LocalDate.now());
 
-        JamiahDto created = service.create(dto);
+        service.create(dto);
         Jamiah entity = repository.findAll().get(0);
         JamiahDto invite = service.createOrRefreshInvitation(entity.getId());
-        JamiahDto joined = service.joinByInvitation(invite.getInvitationCode());
+        UserProfile user = new UserProfile();
+        user.setUsername("user1");
+        user.setUid("u1");
+        userRepository.save(user);
+        JamiahDto joined = service.joinByInvitation(invite.getInvitationCode(), "u1");
         assertEquals(invite.getInvitationCode(), joined.getInvitationCode());
     }
 
@@ -90,13 +99,13 @@ class JamiahServiceTest {
         repository.save(entity);
 
         assertThrows(ResponseStatusException.class,
-                () -> service.joinByInvitation(invite.getInvitationCode()));
+                () -> service.joinByInvitation(invite.getInvitationCode(), "u1"));
     }
 
     @Test
     void joinByInvitationInvalid() {
         assertThrows(ResponseStatusException.class,
-                () -> service.joinByInvitation("INVALID"));
+                () -> service.joinByInvitation("INVALID", "u1"));
     }
 
     @Test
@@ -113,5 +122,38 @@ class JamiahServiceTest {
         JamiahDto created = service.create(dto);
         service.delete(created.getId().toString());
         assertEquals(0, repository.count());
+    }
+
+    @Test
+    void memberCountAndLimit() {
+        JamiahDto dto = new JamiahDto();
+        dto.setName("Limited");
+        dto.setIsPublic(true);
+        dto.setMaxGroupSize(3);
+        dto.setMaxMembers(1);
+        dto.setCycleCount(2);
+        dto.setRateAmount(new BigDecimal("5"));
+        dto.setRateInterval(RateInterval.MONTHLY);
+        dto.setStartDate(LocalDate.now());
+
+        service.create(dto);
+        Jamiah entity = repository.findAll().get(0);
+        JamiahDto invite = service.createOrRefreshInvitation(entity.getId());
+
+        UserProfile user1 = new UserProfile();
+        user1.setUsername("user1");
+        user1.setUid("u1");
+        userRepository.save(user1);
+        service.joinByInvitation(invite.getInvitationCode(), "u1");
+
+        assertEquals(1, repository.countMembers(entity.getId()));
+
+        UserProfile user2 = new UserProfile();
+        user2.setUsername("user2");
+        user2.setUid("u2");
+        userRepository.save(user2);
+
+        assertThrows(ResponseStatusException.class,
+                () -> service.joinByInvitation(invite.getInvitationCode(), "u2"));
     }
 }

--- a/frontend/src/models/Jamiah.ts
+++ b/frontend/src/models/Jamiah.ts
@@ -5,6 +5,8 @@ export interface Jamiah {
   language?: string;
   isPublic: boolean;
   maxGroupSize?: number;
+  maxMembers?: number;
+  currentMembers?: number;
   cycleCount?: number;
   rateAmount?: number;
   rateInterval?: 'WEEKLY' | 'MONTHLY';

--- a/frontend/src/pages/group-details/group-details.tsx
+++ b/frontend/src/pages/group-details/group-details.tsx
@@ -33,8 +33,8 @@ export const GroupDetails = () => {
           {group.language && (
             <Typography variant="body2">Sprache: <b>{group.language}</b></Typography>
           )}
-          {group.maxGroupSize !== undefined && (
-            <Typography variant="body2">Gruppengröße: <b>{group.maxGroupSize}</b></Typography>
+          {group.currentMembers !== undefined && group.maxMembers !== undefined && (
+            <Typography variant="body2">Mitglieder: <b>{group.currentMembers} / {group.maxMembers}</b></Typography>
           )}
           {group.rateAmount !== undefined && (
             <Typography variant="body2">Ratenhöhe: <b>{group.rateAmount}€</b></Typography>
@@ -50,7 +50,9 @@ export const GroupDetails = () => {
           </Typography>
           <Box mt={3}>
             {group.isPublic ? (
-              <Button variant="contained">Jetzt bewerben</Button>
+              <Button variant="contained" disabled={group.maxMembers !== undefined && group.currentMembers !== undefined && group.currentMembers >= group.maxMembers}>
+                Jetzt bewerben
+              </Button>
             ) : (
               <Typography color="textSecondary">Beitritt nur per Einladung</Typography>
             )}

--- a/frontend/src/pages/groups/groups.tsx
+++ b/frontend/src/pages/groups/groups.tsx
@@ -234,8 +234,8 @@ export const Groups = () => {
                           <Typography variant="body2" gutterBottom>Nächste Abrechnung in {info.nextIn} Tagen</Typography>
                         )}
                         <Divider sx={{ my: 1 }} />
-                        {group.maxGroupSize && (
-                          <Typography variant="body2">Max Mitglieder: <b>{group.maxGroupSize}</b></Typography>
+                        {group.currentMembers !== undefined && group.maxMembers !== undefined && (
+                          <Typography variant="body2">Mitglieder: <b>{group.currentMembers} / {group.maxMembers}</b></Typography>
                         )}
                         {group.description && (
                           <Typography variant="body2" sx={{ wordBreak: 'break-word' }}>{group.description}</Typography>

--- a/frontend/src/pages/join-jamiah/join-jamiah.tsx
+++ b/frontend/src/pages/join-jamiah/join-jamiah.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Box, Button, TextField, Typography, Snackbar, Alert } from '@mui/material';
 import { API_BASE_URL } from '../../constants/api';
+import { auth } from '../../firebase_config';
 
 export const JoinJamiahPage = () => {
   const [code, setCode] = useState('');
@@ -9,15 +10,17 @@ export const JoinJamiahPage = () => {
   const [error, setError] = useState(false);
 
   const handleSubmit = () => {
-    fetch(`${API_BASE_URL}/api/jamiahs/join`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ code })
+    const uid = auth.currentUser?.uid || '';
+    fetch(`${API_BASE_URL}/api/jamiahs/join?code=${encodeURIComponent(code)}&uid=${encodeURIComponent(uid)}`, {
+      method: 'POST'
     })
       .then(res => {
         if (res.ok) {
           setMessage('Beitritt erfolgreich angefragt.');
           setError(false);
+        } else if (res.status === 400) {
+          setMessage('Maximale Teilnehmerzahl erreicht.');
+          setError(true);
         } else {
           setMessage('Einladungscode ungültig.');
           setError(true);


### PR DESCRIPTION
## Summary
- allow Jamiah entities to store and track members
- validate member limit when joining
- expose member information via REST and show it in the UI
- add SQL migration for member table
- update tests for new membership logic

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686476dafd1c8333a6eaa55440d4c998