### PR TITLE
Add Jamiah membership tracking for users

### DIFF
--- a/backend/src/main/java/com/example/backend/UserProfile.java
+++ b/backend/src/main/java/com/example/backend/UserProfile.java
@@ -1,6 +1,8 @@
 package com.example.backend;
 
 import jakarta.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "user_profiles", uniqueConstraints = @UniqueConstraint(columnNames = "username"))
@@ -24,6 +26,9 @@ public class UserProfile {
     private String language;
     @Column(length = 2048)
     private String interests;
+
+    @ManyToMany(mappedBy = "members")
+    private Set<com.example.backend.jamiah.Jamiah> jamiahs = new HashSet<>();
 
     public UserProfile() {
     }
@@ -118,5 +123,13 @@ public class UserProfile {
 
     public void setInterests(String interests) {
         this.interests = interests;
+    }
+
+    public Set<com.example.backend.jamiah.Jamiah> getJamiahs() {
+        return jamiahs;
+    }
+
+    public void setJamiahs(Set<com.example.backend.jamiah.Jamiah> jamiahs) {
+        this.jamiahs = jamiahs;
     }
 }

--- a/backend/src/main/java/com/example/backend/UserProfileController.java
+++ b/backend/src/main/java/com/example/backend/UserProfileController.java
@@ -3,6 +3,8 @@ package com.example.backend;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
+import com.example.backend.jamiah.JamiahMapper;
+import java.util.stream.Collectors;
 
 import java.util.List;
 
@@ -11,9 +13,11 @@ import java.util.List;
 @CrossOrigin(origins = "*")
 public class UserProfileController {
     private final UserProfileRepository repository;
+    private final JamiahMapper jamiahMapper;
 
-    public UserProfileController(UserProfileRepository repository) {
+    public UserProfileController(UserProfileRepository repository, JamiahMapper jamiahMapper) {
         this.repository = repository;
+        this.jamiahMapper = jamiahMapper;
     }
 
     @GetMapping
@@ -78,6 +82,15 @@ public class UserProfileController {
         existing.setLanguage(profile.getLanguage());
         existing.setInterests(profile.getInterests());
         return repository.save(existing);
+    }
+
+    @GetMapping("/uid/{uid}/jamiahs")
+    public List<com.example.backend.jamiah.dto.JamiahDto> getJamiahs(@PathVariable String uid) {
+        return repository.findWithJamiahsByUid(uid)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND))
+                .getJamiahs().stream()
+                .map(jamiahMapper::toDto)
+                .collect(Collectors.toList());
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/example/backend/UserProfileRepository.java
+++ b/backend/src/main/java/com/example/backend/UserProfileRepository.java
@@ -3,8 +3,13 @@ package com.example.backend;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
     boolean existsByUsername(String username);
     Optional<UserProfile> findByUid(String uid);
+
+    @Query("select u from UserProfile u left join fetch u.jamiahs where u.uid = :uid")
+    Optional<UserProfile> findWithJamiahsByUid(@Param("uid") String uid);
 }

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
@@ -119,6 +119,7 @@ public class JamiahService {
         com.example.backend.UserProfile user = userRepository.findByUid(uid)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
         entity.getMembers().add(user);
+        user.getJamiahs().add(entity);
         return mapper.toDto(repository.save(entity));
     }
 


### PR DESCRIPTION
## Summary
- track a user's Jamiah groups using a new many-to-many relationship
- expose an endpoint to list Jamiahs for a user
- update service so joining a Jamiah records the membership both ways

## Testing
- `./mvnw test -q` *(fails: could not resolve Spring dependencies)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647bd0f9f88333b6a9f86da5fe11a7