### PR TITLE
Add /profile endpoint and auto-join jamiahs

### DIFF
--- a/backend/src/main/java/com/example/backend/ProfileController.java
+++ b/backend/src/main/java/com/example/backend/ProfileController.java
@@ -1,0 +1,23 @@
+package com.example.backend;
+
+import org.springframework.web.bind.annotation.*;
+
+/** Alias controller to save user profiles via /profile endpoint. */
+import com.example.backend.UserProfile;
+import com.example.backend.UserProfileController;
+
+@RestController
+@RequestMapping("/profile")
+@CrossOrigin(origins = "*")
+public class ProfileController {
+    private final UserProfileController delegate;
+
+    public ProfileController(UserProfileController delegate) {
+        this.delegate = delegate;
+    }
+
+    @PutMapping("/{uid}")
+    public UserProfile saveProfile(@PathVariable String uid, @RequestBody UserProfile profile) {
+        return delegate.updateByUid(uid, profile);
+    }
+}

--- a/backend/src/main/java/com/example/backend/Risk.java
+++ b/backend/src/main/java/com/example/backend/Risk.java
@@ -5,8 +5,6 @@ import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "risks")
@@ -20,10 +18,6 @@ public class Risk {
     @Column(length = 2048)
     private String description;
 
-    @ElementCollection
-    @CollectionTable(name = "risk_types", joinColumns = @JoinColumn(name = "risk_id"))
-    @Column(name = "type")
-    private List<String> type = new ArrayList<>();
 
     private BigDecimal value;
 
@@ -69,13 +63,6 @@ public class Risk {
         this.description = description;
     }
 
-    public List<String> getType() {
-        return type;
-    }
-
-    public void setType(List<String> type) {
-        this.type = type;
-    }
 
     public BigDecimal getValue() {
         return value;

--- a/backend/src/main/java/com/example/backend/RiskController.java
+++ b/backend/src/main/java/com/example/backend/RiskController.java
@@ -43,7 +43,6 @@ public class RiskController {
         Risk existing = riskRepository.findById(id).orElseThrow(() -> new RuntimeException("Risk not found"));
         existing.setName(risk.getName());
         existing.setDescription(risk.getDescription());
-        existing.setType(risk.getType());
         existing.setValue(risk.getValue());
         existing.setDeclinationDate(risk.getDeclinationDate());
         existing.setStatus(risk.getStatus());

--- a/backend/src/main/java/com/example/backend/UserProfileController.java
+++ b/backend/src/main/java/com/example/backend/UserProfileController.java
@@ -93,6 +93,11 @@ public class UserProfileController {
         return repository.save(entity);
     }
 
+    @PutMapping("/profile/{uid}")
+    public UserProfile saveProfile(@PathVariable String uid, @RequestBody UserProfile profile) {
+        return updateByUid(uid, profile);
+    }
+
     @GetMapping("/uid/{uid}/jamiahs")
     public List<com.example.backend.jamiah.dto.JamiahDto> getJamiahs(@PathVariable String uid) {
         return repository.findWithJamiahsByUid(uid)

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
@@ -31,8 +31,8 @@ public class JamiahController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public JamiahDto create(@Valid @RequestBody JamiahDto dto) {
-        return service.create(dto);
+    public JamiahDto create(@Valid @RequestBody JamiahDto dto, @RequestParam(required = false) String uid) {
+        return service.create(dto, uid);
     }
 
     @PutMapping("/{id}")

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
@@ -44,8 +44,18 @@ public class JamiahService {
     }
 
     public JamiahDto create(JamiahDto dto) {
+        return create(dto, null);
+    }
+
+    public JamiahDto create(JamiahDto dto, String uid) {
         validateParameters(dto);
         Jamiah entity = mapper.toEntity(dto);
+        if (uid != null) {
+            com.example.backend.UserProfile user = userRepository.findByUid(uid)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+            entity.getMembers().add(user);
+            user.getJamiahs().add(entity);
+        }
         Jamiah saved = repository.save(entity);
         return mapper.toDto(saved);
     }

--- a/backend/src/main/resources/db/migration/V7__create_user_profiles.sql
+++ b/backend/src/main/resources/db/migration/V7__create_user_profiles.sql
@@ -1,0 +1,15 @@
+CREATE TABLE user_profiles (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    uid VARCHAR(255),
+    username VARCHAR(255) NOT NULL,
+    first_name VARCHAR(255),
+    last_name VARCHAR(255),
+    birth_date VARCHAR(255),
+    gender VARCHAR(255),
+    nationality VARCHAR(255),
+    address VARCHAR(255),
+    phone VARCHAR(255),
+    language VARCHAR(255),
+    interests VARCHAR(2048),
+    CONSTRAINT uk_user_profiles_username UNIQUE (username)
+);

--- a/backend/src/main/resources/db/migration/V8__create_publishers.sql
+++ b/backend/src/main/resources/db/migration/V8__create_publishers.sql
@@ -1,0 +1,7 @@
+CREATE TABLE publishers (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    uid VARCHAR(255),
+    name VARCHAR(255),
+    address VARCHAR(255),
+    age INT
+);

--- a/backend/src/main/resources/db/migration/V9__create_risks.sql
+++ b/backend/src/main/resources/db/migration/V9__create_risks.sql
@@ -1,0 +1,18 @@
+CREATE TABLE risks (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255),
+    description VARCHAR(2048),
+    value DECIMAL(19,2),
+    publisher_id BIGINT,
+    declination_date DATE,
+    created_at DATETIME,
+    updated_at DATETIME,
+    published_at DATETIME,
+    withdrawn_at DATETIME,
+    status VARCHAR(20),
+    risk_category VARCHAR(255),
+    risk_probability DOUBLE,
+    CONSTRAINT fk_risk_publisher FOREIGN KEY (publisher_id) REFERENCES publishers(id)
+);
+
+CREATE INDEX idx_risk_publisher ON risks(publisher_id);


### PR DESCRIPTION
## Summary
- drop unused risk_types migration
- remove type list from `Risk` and controller
- expose new /profile endpoint for saving user profiles
- allow passing `uid` when creating a jamiah and auto-join creator

## Testing
- `./backend/mvnw -f backend/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6867b12b97dc8333bea69d0ce739e069