### PR TITLE
Enable Flyway baseline on migrate

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -10,6 +10,8 @@ server.port=${PORT:8080}
 
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
+spring.flyway.baseline-on-migrate=true
+spring.flyway.baseline-version=0
 
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true


### PR DESCRIPTION
## Summary
- configure Flyway to baseline migrations when tables already exist

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6867bb5852dc83339086d5e8b9927f92