### PR TITLE
Refine Flyway config

### DIFF
--- a/backend/src/main/java/com/example/backend/config/FlywayConfig.java
+++ b/backend/src/main/java/com/example/backend/config/FlywayConfig.java
@@ -1,0 +1,19 @@
+package com.example.backend.config;
+
+import org.flywaydb.core.Flyway;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FlywayConfig {
+
+    @Bean
+    public FlywayMigrationStrategy flywayMigrationStrategy() {
+        return flyway -> {
+            flyway.repair();
+            flyway.migrate();
+        };
+    }
+}
+

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -10,6 +10,8 @@ server.port=${PORT:8080}
 
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
+spring.flyway.user=${SPRING_DATASOURCE_USERNAME}
+spring.flyway.password=${SPRING_DATASOURCE_PASSWORD}
 spring.flyway.baseline-on-migrate=true
 spring.flyway.baseline-version=0
 


### PR DESCRIPTION
## Summary
- rely on existing datasource env vars for Flyway configuration
- remove redundant `application.yaml`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM – network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68685df843c48333837d8ba5e7019067