### PR TITLE
Remove Firestore from profile handling

### DIFF
--- a/backend/src/main/java/com/example/backend/ProfileController.java
+++ b/backend/src/main/java/com/example/backend/ProfileController.java
@@ -16,6 +16,11 @@ public class ProfileController {
         this.delegate = delegate;
     }
 
+    @GetMapping("/{uid}")
+    public UserProfile getProfile(@PathVariable String uid) {
+        return delegate.getByUid(uid);
+    }
+
     @PutMapping("/{uid}")
     public UserProfile saveProfile(@PathVariable String uid, @RequestBody UserProfile profile) {
         return delegate.updateByUid(uid, profile);

--- a/backend/src/main/java/com/example/backend/UserProfileController.java
+++ b/backend/src/main/java/com/example/backend/UserProfileController.java
@@ -25,6 +25,12 @@ public class UserProfileController {
         return repository.findAll();
     }
 
+    @GetMapping("/uid/{uid}")
+    public UserProfile getByUid(@PathVariable String uid) {
+        return repository.findByUid(uid)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    }
+
     @GetMapping("/{id}")
     public UserProfile get(@PathVariable Long id) {
         return repository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));

--- a/frontend/src/pages/authentication/sign-in.tsx
+++ b/frontend/src/pages/authentication/sign-in.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
 import { Box, Button, Typography, Snackbar, Alert, CircularProgress } from "@mui/material";
 import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
-import { auth, db } from "../../firebase_config";
+import { auth } from "../../firebase_config";
 import { useNavigate } from "react-router-dom";
-import { collection, getDocs, query, where } from "firebase/firestore";
 import { ROUTES } from "../../routing/routes";
+import { API_BASE_URL } from "../../constants/api";
 
 export const LoginForm: React.FC = () => {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -26,12 +26,13 @@ export const LoginForm: React.FC = () => {
       const provider = new GoogleAuthProvider();
       const result = await signInWithPopup(auth, provider);
       const user = result.user;
-      const profileQuery = query(collection(db, "userProfiles"), where("uid", "==", user.uid));
-      const profileSnapshot = await getDocs(profileQuery);
-      if (profileSnapshot.empty) {
+      const resp = await fetch(`${API_BASE_URL}/api/userProfiles/uid/${user.uid}`);
+      if (resp.status === 404) {
         navigate(`/${ROUTES.COMPLETE_PROFILE}`);
-      } else {
+      } else if (resp.ok) {
         navigate("/");
+      } else {
+        showError("Profil konnte nicht geladen werden.");
       }
     } catch (err: any) {
       showError("Google-Anmeldung fehlgeschlagen.");


### PR DESCRIPTION
## Summary
- retrieve user profiles from backend instead of Firestore
- add backend REST endpoint to fetch a profile by uid
- update profile forms to read/write only through Spring Boot API
- adjust Google sign‑in flow to check profiles via backend

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692f9b835c833399e49f8fafbc6af3