### PR TITLE
Switch profile image storage to backend

### DIFF
--- a/backend/src/main/java/com/example/backend/UserProfile.java
+++ b/backend/src/main/java/com/example/backend/UserProfile.java
@@ -27,6 +27,13 @@ public class UserProfile {
     @Column(length = 2048)
     private String interests;
 
+    @Lob
+    @Basic(fetch = FetchType.LAZY)
+    @Column(name = "profile_image")
+    private byte[] profileImage;
+
+    private String profileImageType;
+
     @ManyToMany(mappedBy = "members")
     private Set<com.example.backend.jamiah.Jamiah> jamiahs = new HashSet<>();
 
@@ -123,6 +130,22 @@ public class UserProfile {
 
     public void setInterests(String interests) {
         this.interests = interests;
+    }
+
+    public byte[] getProfileImage() {
+        return profileImage;
+    }
+
+    public void setProfileImage(byte[] profileImage) {
+        this.profileImage = profileImage;
+    }
+
+    public String getProfileImageType() {
+        return profileImageType;
+    }
+
+    public void setProfileImageType(String profileImageType) {
+        this.profileImageType = profileImageType;
     }
 
     public Set<com.example.backend.jamiah.Jamiah> getJamiahs() {

--- a/backend/src/main/resources/db/migration/V11__add_profile_image.sql
+++ b/backend/src/main/resources/db/migration/V11__add_profile_image.sql
@@ -1,0 +1,3 @@
+ALTER TABLE user_profiles
+    ADD COLUMN profile_image LONGBLOB,
+    ADD COLUMN profile_image_type VARCHAR(255);

--- a/frontend/src/firebase/firebase-service.ts
+++ b/frontend/src/firebase/firebase-service.ts
@@ -1,4 +1,5 @@
-import { auth, googleAuthProvider, storage } from '../firebase_config';
+import { auth, googleAuthProvider } from '../firebase_config';
+import { API_BASE_URL } from '../constants/api';
 import {
     signInWithPopup,
     signOut,
@@ -6,7 +7,6 @@ import {
     signInWithEmailAndPassword,
 
 } from "firebase/auth";
-import { ref, uploadBytes, getDownloadURL, deleteObject } from "firebase/storage";
 
 export const signInWithGoogle = async () => {
     try {
@@ -56,10 +56,16 @@ export const signInWithEmail = async (email: string, password: string) => {
 
 export const uploadProfileImage = async (uid: string, file: File): Promise<string | null> => {
     try {
-        const imageRef = ref(storage, `profile_images/${uid}`);
-        await uploadBytes(imageRef, file);
-        const url = await getDownloadURL(imageRef);
-        return url;
+        const formData = new FormData();
+        formData.append('file', file);
+        const resp = await fetch(`${API_BASE_URL}/api/userProfiles/uid/${uid}/image`, {
+            method: 'POST',
+            body: formData
+        });
+        if (resp.ok) {
+            return `${API_BASE_URL}/api/userProfiles/uid/${uid}/image`;
+        }
+        return null;
     } catch (error) {
         console.error('Error uploading profile image:', error);
         return null;
@@ -68,9 +74,10 @@ export const uploadProfileImage = async (uid: string, file: File): Promise<strin
 
 export const deleteProfileImage = async (uid: string): Promise<boolean> => {
     try {
-        const imageRef = ref(storage, `profile_images/${uid}`);
-        await deleteObject(imageRef);
-        return true;
+        const resp = await fetch(`${API_BASE_URL}/api/userProfiles/uid/${uid}/image`, {
+            method: 'DELETE'
+        });
+        return resp.ok;
     } catch (error) {
         console.error('Error deleting profile image:', error);
         return false;


### PR DESCRIPTION
## Summary
- add Flyway migration to store profile images
- extend `UserProfile` entity with image fields
- expose new upload, fetch and delete endpoints for profile images
- route frontend's profile image helpers to backend API instead of Firebase

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM due to network)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab2c15f508333a54ae4b9d48028cf