### PR TITLE
Fix join logic when already member

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
@@ -123,14 +123,17 @@ public class JamiahService {
         if (entity.getInvitationExpiry() != null && entity.getInvitationExpiry().isBefore(LocalDate.now())) {
             throw new ResponseStatusException(HttpStatus.GONE);
         }
-        if (entity.getMaxMembers() != null && entity.getMembers().size() >= entity.getMaxMembers()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Member limit reached");
-        }
         com.example.backend.UserProfile user = userRepository.findByUid(uid)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
-        entity.getMembers().add(user);
-        user.getJamiahs().add(entity);
-        return mapper.toDto(repository.save(entity));
+        if (!entity.getMembers().contains(user)) {
+            if (entity.getMaxMembers() != null && entity.getMembers().size() >= entity.getMaxMembers()) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Member limit reached");
+            }
+            entity.getMembers().add(user);
+            user.getJamiahs().add(entity);
+            repository.save(entity);
+        }
+        return mapper.toDto(entity);
     }
 
     public void delete(String publicId) {

--- a/backend/src/test/java/com/example/backend/jamiah/JamiahServiceTest.java
+++ b/backend/src/test/java/com/example/backend/jamiah/JamiahServiceTest.java
@@ -156,4 +156,30 @@ class JamiahServiceTest {
         assertThrows(ResponseStatusException.class,
                 () -> service.joinByInvitation(invite.getInvitationCode(), "u2"));
     }
+
+    @Test
+    void joinByInvitationAlreadyMember() {
+        JamiahDto dto = new JamiahDto();
+        dto.setName("ExistingMember");
+        dto.setIsPublic(true);
+        dto.setMaxGroupSize(3);
+        dto.setCycleCount(2);
+        dto.setRateAmount(new BigDecimal("5"));
+        dto.setRateInterval(RateInterval.MONTHLY);
+        dto.setStartDate(LocalDate.now());
+
+        service.create(dto);
+        Jamiah entity = repository.findAll().get(0);
+        JamiahDto invite = service.createOrRefreshInvitation(entity.getId());
+
+        UserProfile user = new UserProfile();
+        user.setUsername("user1");
+        user.setUid("u1");
+        userRepository.save(user);
+
+        service.joinByInvitation(invite.getInvitationCode(), "u1");
+        service.joinByInvitation(invite.getInvitationCode(), "u1");
+
+        assertEquals(1, repository.countMembers(entity.getId()));
+    }
 }


### PR DESCRIPTION
## Summary
- prevent duplicate membership on join
- add regression test for joining twice

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686aeb24c67c8333a7d448ee4da695ea