### PR TITLE
Add owner assignment to jamiahs

### DIFF
--- a/backend/src/main/java/com/example/backend/UserProfileController.java
+++ b/backend/src/main/java/com/example/backend/UserProfileController.java
@@ -3,8 +3,6 @@ package com.example.backend;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-import com.example.backend.jamiah.JamiahMapper;
-import java.util.stream.Collectors;
 
 import java.util.List;
 
@@ -13,11 +11,12 @@ import java.util.List;
 @CrossOrigin(origins = "*")
 public class UserProfileController {
     private final UserProfileRepository repository;
-    private final JamiahMapper jamiahMapper;
+    private final com.example.backend.jamiah.JamiahService jamiahService;
 
-    public UserProfileController(UserProfileRepository repository, JamiahMapper jamiahMapper) {
+    public UserProfileController(UserProfileRepository repository,
+                                 com.example.backend.jamiah.JamiahService jamiahService) {
         this.repository = repository;
-        this.jamiahMapper = jamiahMapper;
+        this.jamiahService = jamiahService;
     }
 
     @GetMapping
@@ -144,11 +143,7 @@ public class UserProfileController {
 
     @GetMapping("/uid/{uid}/jamiahs")
     public List<com.example.backend.jamiah.dto.JamiahDto> getJamiahs(@PathVariable String uid) {
-        return repository.findWithJamiahsByUid(uid)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND))
-                .getJamiahs().stream()
-                .map(jamiahMapper::toDto)
-                .collect(Collectors.toList());
+        return jamiahService.getJamiahsForUser(uid);
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/example/backend/jamiah/Jamiah.java
+++ b/backend/src/main/java/com/example/backend/jamiah/Jamiah.java
@@ -17,6 +17,11 @@ public class Jamiah {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /**
+     * UID of the user who created this Jamiah.
+     */
+    private String ownerId;
+
     @NotBlank
     @Size(min = 3)
     @Column(nullable = false)
@@ -57,4 +62,12 @@ public class Jamiah {
             joinColumns = @JoinColumn(name = "jamiah_id"),
             inverseJoinColumns = @JoinColumn(name = "user_profile_id"))
     private Set<com.example.backend.UserProfile> members = new HashSet<>();
+
+    public String getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(String ownerId) {
+        this.ownerId = ownerId;
+    }
 }

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
@@ -31,8 +31,11 @@ public class JamiahController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public JamiahDto create(@Valid @RequestBody JamiahDto dto, @RequestParam(required = false) String uid) {
-        return service.create(dto, uid);
+    public JamiahDto create(@Valid @RequestBody JamiahDto dto,
+                            @org.springframework.security.core.annotation.AuthenticationPrincipal
+                                    org.springframework.security.oauth2.jwt.Jwt jwt) {
+        String uid = jwt != null ? jwt.getSubject() : null;
+        return service.createJamiah(uid, dto);
     }
 
     @PutMapping("/{id}")

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahRepository.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahRepository.java
@@ -14,4 +14,9 @@ public interface JamiahRepository extends JpaRepository<Jamiah, Long> {
 
     @Query("select count(m) from Jamiah j join j.members m where j.id = :id")
     long countMembers(@Param("id") Long id);
+
+    /**
+     * Find all Jamiahs created by the given user.
+     */
+    java.util.List<Jamiah> findByOwnerId(String ownerId);
 }

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
@@ -60,6 +60,23 @@ public class JamiahService {
         return mapper.toDto(saved);
     }
 
+    /**
+     * Create a new Jamiah for the given owner.
+     */
+    public JamiahDto createJamiah(String ownerUid, JamiahDto dto) {
+        validateParameters(dto);
+        Jamiah j = mapper.toEntity(dto);
+        j.setOwnerId(ownerUid);
+        if (ownerUid != null) {
+            com.example.backend.UserProfile user = userRepository.findByUid(ownerUid)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+            j.getMembers().add(user);
+            user.getJamiahs().add(j);
+        }
+        Jamiah saved = repository.save(j);
+        return mapper.toDto(saved);
+    }
+
     public JamiahDto update(Long id, JamiahDto dto) {
         validateParameters(dto);
         Jamiah entity = repository.findById(id)
@@ -111,6 +128,15 @@ public class JamiahService {
     public JamiahDto findByPublicId(String publicId) {
         Jamiah entity = getByPublicId(publicId);
         return mapper.toDto(entity);
+    }
+
+    /**
+     * Retrieve all Jamiahs owned by the specified user.
+     */
+    public java.util.List<JamiahDto> getJamiahsForUser(String ownerUid) {
+        return repository.findByOwnerId(ownerUid).stream()
+                .map(mapper::toDto)
+                .collect(java.util.stream.Collectors.toList());
     }
 
     public JamiahDto joinByInvitation(String code, String uid) {

--- a/backend/src/main/resources/db/migration/V12__add_owner_id_to_jamiah.sql
+++ b/backend/src/main/resources/db/migration/V12__add_owner_id_to_jamiah.sql
@@ -1,0 +1,2 @@
+ALTER TABLE jamiah
+    ADD COLUMN owner_id VARCHAR(255);

--- a/backend/src/test/java/com/example/backend/jamiah/JamiahServiceTest.java
+++ b/backend/src/test/java/com/example/backend/jamiah/JamiahServiceTest.java
@@ -199,10 +199,35 @@ class JamiahServiceTest {
         dto.setRateInterval(RateInterval.MONTHLY);
         dto.setStartDate(LocalDate.now());
 
-        service.create(dto, "uid123");
+        service.createJamiah("uid123", dto);
         Jamiah jamiah = repository.findAll().get(0);
 
         assertEquals(1, jamiah.getMembers().size());
         assertTrue(jamiah.getMembers().contains(user));
+        assertEquals("uid123", jamiah.getOwnerId());
+    }
+
+    @Test
+    void getJamiahsForUserReturnsOwnedJamiahs() {
+        UserProfile user = new UserProfile();
+        user.setUsername("owner");
+        user.setUid("owner1");
+        userRepository.save(user);
+
+        JamiahDto dto = new JamiahDto();
+        dto.setName("Owned Group");
+        dto.setIsPublic(true);
+        dto.setMaxGroupSize(3);
+        dto.setCycleCount(1);
+        dto.setRateAmount(new BigDecimal("5"));
+        dto.setRateInterval(RateInterval.MONTHLY);
+        dto.setStartDate(LocalDate.now());
+
+        service.createJamiah("owner1", dto);
+
+        List<JamiahDto> jamiahs = service.getJamiahsForUser("owner1");
+
+        assertEquals(1, jamiahs.size());
+        assertEquals("Owned Group", jamiahs.get(0).getName());
     }
 }

--- a/frontend/src/pages/groups/groups.tsx
+++ b/frontend/src/pages/groups/groups.tsx
@@ -44,6 +44,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import { Jamiah } from '../../models/Jamiah';
 import { API_BASE_URL } from '../../constants/api';
 import { auth } from '../../firebase_config';
+import { useAuth } from '../../context/AuthContext';
 import { GenerateInviteButton } from '../../components/jamiah/GenerateInviteButton';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '../../routing/routes';
@@ -78,9 +79,10 @@ export const Groups = () => {
   const isMobile = useMediaQuery('(max-width:600px)');
   const steps = ['Name & Typ', 'Beitrag & Zyklus', 'Gruppengröße & Startdatum'];
   const [activeStep, setActiveStep] = useState(0);
+  const { user } = useAuth();
 
   useEffect(() => {
-    const uid = auth.currentUser?.uid;
+    const uid = user?.uid;
     if (!uid) {
       setGroups([]);
       setLoading(false);
@@ -521,7 +523,7 @@ export const Groups = () => {
                     setCreateErrors({ name: true });
                     return;
                   }
-                  const uid = auth.currentUser?.uid;
+                  const uid = user?.uid;
                   const url = uid
                     ? `${API_BASE_URL}/api/jamiahs?uid=${encodeURIComponent(uid)}`
                     : `${API_BASE_URL}/api/jamiahs`;


### PR DESCRIPTION
## Summary
- add ownerId to Jamiah entity and expose getters/setters
- extend JamiahRepository with lookup by owner
- implement `createJamiah` and `getJamiahsForUser` in service
- read uid from JWT in `POST /api/jamiahs`
- return jamiahs for a user via service from `UserProfileController`
- adjust frontend groups page to read uid from auth context
- add Flyway migration for owner_id
- update tests for new functionality

## Testing
- `./mvnw test -q` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686af74ae2f08333bdfc39d1e264cd17