### PR TITLE
Fix groups page not loading user jamiahs

### DIFF
--- a/frontend/src/pages/groups/groups.tsx
+++ b/frontend/src/pages/groups/groups.tsx
@@ -94,7 +94,7 @@ export const Groups = () => {
       .then(setGroups)
       .catch(() => setGroups([]))
       .finally(() => setLoading(false));
-  }, []);
+  }, [user]);
 
   const navigate = useNavigate();
   const handleCreateOpen = () => setOpenCreateModal(true);


### PR DESCRIPTION
## Summary
- update `useEffect` dependency so groups load after user info is available

## Testing
- `npm --prefix frontend test --silent`
- `./backend/mvnw test` *(fails: could not resolve Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686b04a5be6c8333904a146fb6a11673