### PR TITLE
Add public jamiah listing and join

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
@@ -24,6 +24,11 @@ public class JamiahController {
         return service.findAll();
     }
 
+    @GetMapping("/public")
+    public List<JamiahDto> listPublic() {
+        return service.findAllPublic();
+    }
+
     @GetMapping("/{id}")
     public JamiahDto get(@PathVariable String id) {
         return service.findByPublicId(id);
@@ -51,6 +56,11 @@ public class JamiahController {
     @PostMapping("/join")
     public JamiahDto join(@RequestParam String code, @RequestParam String uid) {
         return service.joinByInvitation(code, uid);
+    }
+
+    @PostMapping("/{id}/join-public")
+    public JamiahDto joinPublic(@PathVariable String id, @RequestParam String uid) {
+        return service.joinPublic(id, uid);
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahRepository.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahRepository.java
@@ -16,6 +16,17 @@ public interface JamiahRepository extends JpaRepository<Jamiah, Long> {
     long countMembers(@Param("id") Long id);
 
     /**
+     * Find all public Jamiahs.
+     */
+    java.util.List<Jamiah> findByIsPublicTrue();
+
+    /**
+     * Fetch a Jamiah with members by numeric id.
+     */
+    @Query("select j from Jamiah j left join fetch j.members where j.id = :id")
+    Optional<Jamiah> findWithMembersById(@Param("id") Long id);
+
+    /**
      * Find all Jamiahs created by the given user.
      */
     java.util.List<Jamiah> findByOwnerId(String ownerId);

--- a/backend/src/test/java/com/example/backend/jamiah/JamiahServiceTest.java
+++ b/backend/src/test/java/com/example/backend/jamiah/JamiahServiceTest.java
@@ -231,4 +231,54 @@ class JamiahServiceTest {
         assertEquals(1, jamiahs.size());
         assertEquals("Owned Group", jamiahs.get(0).getName());
     }
+
+    @Test
+    void findAllPublicReturnsOnlyPublicJamiahs() {
+        JamiahDto pub = new JamiahDto();
+        pub.setName("Public");
+        pub.setIsPublic(true);
+        pub.setMaxGroupSize(3);
+        pub.setCycleCount(1);
+        pub.setRateAmount(new BigDecimal("5"));
+        pub.setRateInterval(RateInterval.MONTHLY);
+        pub.setStartDate(LocalDate.now());
+
+        JamiahDto priv = new JamiahDto();
+        priv.setName("Private");
+        priv.setIsPublic(false);
+        priv.setMaxGroupSize(3);
+        priv.setCycleCount(1);
+        priv.setRateAmount(new BigDecimal("5"));
+        priv.setRateInterval(RateInterval.MONTHLY);
+        priv.setStartDate(LocalDate.now());
+
+        service.create(pub);
+        service.create(priv);
+
+        List<JamiahDto> all = service.findAllPublic();
+        assertEquals(1, all.size());
+        assertEquals("Public", all.get(0).getName());
+    }
+
+    @Test
+    void joinPublicAddsMember() {
+        JamiahDto dto = new JamiahDto();
+        dto.setName("JoinablePublic");
+        dto.setIsPublic(true);
+        dto.setMaxGroupSize(3);
+        dto.setCycleCount(1);
+        dto.setRateAmount(new BigDecimal("5"));
+        dto.setRateInterval(RateInterval.MONTHLY);
+        dto.setStartDate(LocalDate.now());
+
+        JamiahDto created = service.create(dto);
+        UserProfile user = new UserProfile();
+        user.setUsername("member");
+        user.setUid("m1");
+        userRepository.save(user);
+
+        JamiahDto joined = service.joinPublic(created.getId().toString(), "m1");
+        assertEquals(1, repository.countMembers(repository.findAll().get(0).getId()));
+        assertEquals(created.getId(), joined.getId());
+    }
 }


### PR DESCRIPTION
## Summary
- allow listing public jamiahs and joining without invite
- add REST support to query public jamiahs and join them
- show public jamiahs on the groups page with join button
- mark joined public jamiahs with a label
- extend backend tests for new functionality

## Testing
- `mvn test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ba25319008333b063a68e1cda77fa