### PR TITLE
Improve join public Jamiah error handling

### DIFF
--- a/frontend/src/pages/groups/groups.tsx
+++ b/frontend/src/pages/groups/groups.tsx
@@ -119,10 +119,28 @@ export const Groups = () => {
     fetch(`${API_BASE_URL}/api/jamiahs/${group.id}/join-public?uid=${encodeURIComponent(uid)}`, {
       method: 'POST'
     })
-      .then(res => res.json())
-      .then(j => {
-        setGroups([...groups, j]);
-      });
+      .then(async res => {
+        if (res.ok) {
+          const j = await res.json();
+          setGroups([...groups, j]);
+          setSnackbarMessage('Beitritt erfolgreich');
+          setSnackbarError(false);
+        } else if (res.status === 400) {
+          setSnackbarMessage('Maximale Teilnehmerzahl erreicht');
+          setSnackbarError(true);
+        } else if (res.status === 404) {
+          setSnackbarMessage('Jamiah nicht gefunden');
+          setSnackbarError(true);
+        } else {
+          setSnackbarMessage('Fehler beim Beitreten');
+          setSnackbarError(true);
+        }
+      })
+      .catch(() => {
+        setSnackbarMessage('Fehler beim Beitreten');
+        setSnackbarError(true);
+      })
+      .finally(() => setSnackbarOpen(true));
   };
 
   const getCycleInfo = (g: Jamiah) => {
@@ -149,6 +167,7 @@ export const Groups = () => {
   }, [search, visibilityFilter, statusFilter]);
 
   const filteredGroups = groups
+    .filter(g => g && g.name)
     .filter(g => g.name.toLowerCase().includes(search.toLowerCase()))
     .filter(g =>
       visibilityFilter === 'all'


### PR DESCRIPTION
## Summary
- handle error cases when joining a public Jamiah so the UI doesn't crash
- ignore undefined groups when filtering lists

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686bad5ed0588333a94317ddd29da41f