### PR TITLE
Remove obsolete complete-profile route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,6 @@ import {Navigate, Route, Routes} from "react-router-dom";
 import {Landing} from "./pages/landing/landing";
 import {LoginForm} from "./pages/authentication/sign-in";
 import {ForgotPassword} from "./pages/authentication/forgot-password";
-import { CompleteProfile } from "./pages/complete-profile/complete-profile";
 import {RiskOverview} from "./pages/risk-overview/risk-overview";
 import {Layout} from "./components/layout/layout";
 import {Legal} from "./pages/formalities/legal";
@@ -44,7 +43,6 @@ function App() {
                 <Route path={`/${ROUTES.SIGN_IN}`} element={<LoginForm />} />
                 <Route path={`/${ROUTES.FORGOT_PASSWORD}`} element={<ForgotPassword />} />
                 <Route path="/verify-email" element={<VerifyEmail />} />
-                <Route path={`/${ROUTES.COMPLETE_PROFILE}`} element={<CompleteProfile />} />
 
                 {/* Private routes */}
                 <Route path={`/${ROUTES.DASHBOARD}`} element={<PrivateRoute><Dashboard /></PrivateRoute>} />

--- a/frontend/src/pages/authentication/sign-in.tsx
+++ b/frontend/src/pages/authentication/sign-in.tsx
@@ -28,7 +28,7 @@ export const LoginForm: React.FC = () => {
       const user = result.user;
       const resp = await fetch(`${API_BASE_URL}/api/userProfiles/uid/${user.uid}`);
       if (resp.status === 404) {
-        navigate(`/${ROUTES.COMPLETE_PROFILE}`);
+        navigate(`/${ROUTES.PROFILE}`);
       } else if (resp.ok) {
         navigate("/");
       } else {

--- a/frontend/src/routing/routes.ts
+++ b/frontend/src/routing/routes.ts
@@ -24,7 +24,6 @@ export const ROUTES = {
     DOCUMENTS: 'documents',
     REPORTS: 'reports',
     ONBOARDING: 'onboarding',
-    COMPLETE_PROFILE: 'complete-profile',
 
     JOIN_JAMIAH: 'join-jamiah',
 


### PR DESCRIPTION
## Summary
- remove COMPLETE_PROFILE from routes
- redirect new users to `/profile`
- drop unused route from app routing

## Testing
- `CI=true npm test -- --passWithNoTests`
- `./mvnw -q test` *(fails: Could not download spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_686bbdf8ad0c83338320e89f5d8c5d6f