### PR TITLE
Simplify header navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import {Votes} from "./pages/votes/votes";
 import {Documents} from "./pages/documents/documents";
 import {Reports} from "./pages/reports/reports";
 import {Members} from "./pages/memebers/members";
+import JamiahLayout from "./components/layout/jamiah-layout";
 import {Onboarding} from "./pages/onboarding/onboarding";
 import { JoinJamiahPage } from "./pages/join-jamiah/join-jamiah";
 import { GroupDetails } from "./pages/group-details/group-details";
@@ -45,6 +46,15 @@ function App() {
                 <Route path="/verify-email" element={<VerifyEmail />} />
 
                 {/* Private routes */}
+                <Route path="/jamiah/:groupId/*" element={<PrivateRoute><JamiahLayout /></PrivateRoute>}>
+                    <Route index element={<Navigate to="dashboard" replace />} />
+                    <Route path="dashboard" element={<Dashboard />} />
+                    <Route path="members" element={<Members />} />
+                    <Route path="payments" element={<Payments />} />
+                    <Route path="votes" element={<Votes />} />
+                    <Route path="documents" element={<Documents />} />
+                    <Route path="reports" element={<Reports />} />
+                </Route>
                 <Route path={`/${ROUTES.DASHBOARD}`} element={<PrivateRoute><Dashboard /></PrivateRoute>} />
                 <Route path={`/${ROUTES.GROUPS}`} element={<PrivateRoute><Groups /></PrivateRoute>} />
                 <Route path={`/${ROUTES.MEMBERS}`} element={<PrivateRoute><Members /></PrivateRoute>} />

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -11,21 +11,19 @@ import Container from '@mui/material/Container';
 import Button from '@mui/material/Button';
 import MenuItem from '@mui/material/MenuItem';
 import Logo from "../../assests/imgs/jamiah_logo.png";
-import {useLocation, useNavigate} from "react-router-dom";
-import {Page, pages} from "./pages";
+import {useNavigate, useParams} from "react-router-dom";
 import {auth} from "../../firebase_config";
 import {useTheme} from '@mui/material';
 import {QuickMenuButtons} from "./header-elements/quick-menu-buttons";
 
 export function Header() {
-    const location = useLocation();
     const navigate = useNavigate();
+    const { groupId } = useParams<{ groupId: string }>();
     const theme = useTheme();
 
     const [isLoggedIn, setIsLoggedIn] = React.useState<boolean>(false);
     const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(null);
     const [anchorElUser, setAnchorElUser] = React.useState<null | HTMLElement>(null);
-    const [activePage, setActivePage] = React.useState<string | null>(pages[0].name);
 
     useEffect(() => {
         const unsubscribe = auth.onAuthStateChanged(user => {
@@ -35,14 +33,6 @@ export function Header() {
         return () => unsubscribe();
     }, []);
 
-    useEffect(() => {
-        if (location.pathname === "/")
-            setActivePage(pages[0].name);
-        else {
-            const currentPage = pages.find(page => location.pathname === `/${page.route}`);
-            setActivePage(currentPage ? currentPage.name : null);
-        }
-    }, [location]);
 
     const handleOpenNavMenu = (event: React.MouseEvent<HTMLElement>) => {
         setAnchorElNav(event.currentTarget);
@@ -52,13 +42,12 @@ export function Header() {
         setAnchorElUser(event.currentTarget);
     };
 
-    const handleCloseNavMenu = (page: Page) => {
-        setActivePage(page.name);
+    const handleCloseNavMenu = () => {
         setAnchorElNav(null);
-        navigate(page.route);
+        if (groupId) navigate(`/jamiah/${groupId}`);
     };
 
-    const handleCloseUserMenu = (setting: Page) => {
+    const handleCloseUserMenu = (setting: any) => {
         setAnchorElUser(null);
         navigate(setting.route)
     };
@@ -99,12 +88,9 @@ export function Header() {
                             onClose={() => setAnchorElNav(null)}
                             sx={{display: {xs: 'block', md: 'none'}}}>
 
-                            {pages.map((page) => (
-                                page.authenticated && !isLoggedIn ? null :
-                                <MenuItem key={page.name} onClick={() => handleCloseNavMenu(page)}>
-                                    <Typography sx={{textAlign: 'center'}}>{page.name}</Typography>
-                                </MenuItem>
-                            ))}
+                            <MenuItem onClick={handleCloseNavMenu}>
+                                <Typography sx={{textAlign: 'center'}}>Übersicht</Typography>
+                            </MenuItem>
                         </Menu>
                     </Box>
 
@@ -126,22 +112,17 @@ export function Header() {
                     </Typography>
 
                     <Box sx={{flexGrow: 1, display: {xs: 'none', md: 'flex'}}}>
-                        {pages.map((page) => (
-                            page.authenticated && !isLoggedIn ? null :
-                            <Button
-                                key={page.name}
-                                onClick={() => handleCloseNavMenu(page)}
-                                sx={{
-                                    my: 2,
-                                    color: activePage === page.name ? theme.palette.primary.main : 'white',
-                                    display: 'block',
-                                    textDecoration: 'none',
-                                    textDecorationColor: 'white',
-                                    fontWeight: activePage === page.name ? 'bold' : 'normal'
-                                }}>
-                                {page.name}
-                            </Button>
-                        ))}
+                        <Button
+                            onClick={handleCloseNavMenu}
+                            sx={{
+                                my: 2,
+                                color: 'white',
+                                display: 'block',
+                                textDecoration: 'none',
+                                textDecorationColor: 'white'
+                            }}>
+                            Übersicht
+                        </Button>
                     </Box>
                     <QuickMenuButtons
                         isLoggedIn={isLoggedIn}

--- a/frontend/src/components/layout/jamiah-layout.tsx
+++ b/frontend/src/components/layout/jamiah-layout.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Box, Drawer, List, ListItem, ListItemText, Toolbar } from '@mui/material';
+import { Outlet, Link } from 'react-router-dom';
+
+const drawerWidth = 220;
+
+export const JamiahLayout: React.FC = () => {
+  const menu = [
+    { text: 'Dashboard', path: `dashboard` },
+    { text: 'Mitglieder', path: `members` },
+    { text: 'Beiträge', path: `payments` },
+    { text: 'Abstimmungen', path: `votes` },
+    { text: 'Dokumente', path: `documents` },
+    { text: 'Berichte', path: `reports` },
+  ];
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <Drawer
+        variant="permanent"
+        sx={{
+          width: drawerWidth,
+          flexShrink: 0,
+          [`& .MuiDrawer-paper`]: { width: drawerWidth, boxSizing: 'border-box' },
+        }}
+      >
+        <Toolbar />
+        <List>
+          {menu.map(item => (
+            <ListItem button key={item.text} component={Link} to={item.path}>
+              <ListItemText primary={item.text} />
+            </ListItem>
+          ))}
+        </List>
+      </Drawer>
+      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+        <Toolbar />
+        <Outlet />
+      </Box>
+    </Box>
+  );
+};
+
+export default JamiahLayout;

--- a/frontend/src/pages/groups/groups.tsx
+++ b/frontend/src/pages/groups/groups.tsx
@@ -110,8 +110,7 @@ export const Groups = () => {
   const handleJoinOpen = () => navigate(`/${ROUTES.JOIN_JAMIAH}`);
   const handleCloseModal = () => setOpenModal(false);
   const handleDetails = (group: Jamiah) => {
-    setSelectedGroup(group);
-    setOpenModal(true);
+    navigate(`/jamiah/${group.id}`);
   };
 
   const handleJoinPublic = (group: Jamiah) => {


### PR DESCRIPTION
## Summary
- add `/jamiah/:groupId` route for dashboard access
- remove old navigation menu from `Header`
- show only one link "Übersicht" pointing to current group

## Testing
- `npm test --silent` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_686be167437483338d1a788df546893d