### PR TITLE
Restrict Jamiah modifications to owner

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
@@ -44,13 +44,16 @@ public class JamiahController {
     }
 
     @PutMapping("/{id}")
-    public JamiahDto update(@PathVariable String id, @Valid @RequestBody JamiahDto dto) {
-        return service.update(id, dto);
+    public JamiahDto update(@PathVariable String id,
+                            @RequestParam(required = false) String uid,
+                            @Valid @RequestBody JamiahDto dto) {
+        return service.update(id, dto, uid);
     }
 
     @PostMapping("/{id}/invite")
-    public JamiahDto invite(@PathVariable String id) {
-        return service.createOrRefreshInvitation(id);
+    public JamiahDto invite(@PathVariable String id,
+                            @RequestParam(required = false) String uid) {
+        return service.createOrRefreshInvitation(id, uid);
     }
 
     @PostMapping("/join")
@@ -65,7 +68,8 @@ public class JamiahController {
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable String id) {
-        service.delete(id);
+    public void delete(@PathVariable String id,
+                       @RequestParam(required = false) String uid) {
+        service.delete(id, uid);
     }
 }

--- a/backend/src/test/java/com/example/backend/jamiah/JamiahControllerTest.java
+++ b/backend/src/test/java/com/example/backend/jamiah/JamiahControllerTest.java
@@ -192,6 +192,33 @@ class JamiahControllerTest {
     }
 
     @Test
+    void deleteJamiahForbiddenForNonOwner() throws Exception {
+        UserProfile user = new UserProfile();
+        user.setUsername("owner");
+        user.setUid("uidA");
+        userRepository.save(user);
+
+        JamiahDto dto = new JamiahDto();
+        dto.setName("Protected");
+        dto.setIsPublic(true);
+        dto.setMaxGroupSize(3);
+        dto.setCycleCount(1);
+        dto.setRateAmount(new BigDecimal("5"));
+        dto.setRateInterval(RateInterval.MONTHLY);
+        dto.setStartDate(LocalDate.now());
+
+        String response = mockMvc.perform(post("/api/jamiahs?uid=uidA")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andReturn().getResponse().getContentAsString();
+        JamiahDto created = objectMapper.readValue(response, JamiahDto.class);
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .delete("/api/jamiahs/" + created.getId() + "?uid=other"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void listPublicJamiahs() throws Exception {
         JamiahDto dto = new JamiahDto();
         dto.setName("Public");

--- a/backend/src/test/java/com/example/backend/jamiah/JamiahServiceTest.java
+++ b/backend/src/test/java/com/example/backend/jamiah/JamiahServiceTest.java
@@ -209,6 +209,28 @@ class JamiahServiceTest {
     }
 
     @Test
+    void onlyOwnerCanModify() {
+        UserProfile owner = new UserProfile();
+        owner.setUsername("owner");
+        owner.setUid("ownerA");
+        userRepository.save(owner);
+
+        JamiahDto dto = new JamiahDto();
+        dto.setName("Protected");
+        dto.setIsPublic(true);
+        dto.setMaxGroupSize(3);
+        dto.setCycleCount(1);
+        dto.setRateAmount(new BigDecimal("5"));
+        dto.setRateInterval(RateInterval.MONTHLY);
+        dto.setStartDate(LocalDate.now());
+
+        JamiahDto created = service.createJamiah("ownerA", dto);
+
+        assertThrows(ResponseStatusException.class,
+                () -> service.delete(created.getId().toString(), "intruder"));
+    }
+
+    @Test
     void getJamiahsForUserReturnsOwnedJamiahs() {
         UserProfile user = new UserProfile();
         user.setUsername("owner");


### PR DESCRIPTION
## Summary
- allow Jamiah CRUD only for the creator
- pass optional user id through JamiahController
- cover owner permissions with new unit tests

## Testing
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-starter-parent-3.3.0.pom)*

------
https://chatgpt.com/codex/tasks/task_e_686c2f80ea6c8333ac515ef2ad9eff94