### PR TITLE
Update invite generation

### DIFF
--- a/frontend/src/components/jamiah/GenerateInviteButton.tsx
+++ b/frontend/src/components/jamiah/GenerateInviteButton.tsx
@@ -3,6 +3,7 @@ import { Button } from '@mui/material';
 import KeyIcon from '@mui/icons-material/VpnKey';
 import { API_BASE_URL } from '../../constants/api';
 import { InviteCodeDialog } from './InviteCodeDialog';
+import { auth } from '../../firebase_config';
 
 interface GenerateInviteButtonProps {
   jamiahId: string | number;
@@ -13,10 +14,17 @@ export const GenerateInviteButton: React.FC<GenerateInviteButtonProps> = ({ jami
   const [invite, setInvite] = useState<{ invitationCode: string; invitationExpiry: string } | null>(null);
 
   const handleClick = () => {
-    fetch(`${API_BASE_URL}/api/jamiahs/${jamiahId}/invite`, { method: 'POST' })
-      .then(res => res.json())
-      .then(data => setInvite({ invitationCode: data.invitationCode, invitationExpiry: data.invitationExpiry }))
-      .catch(() => setInvite({ invitationCode: 'Fehler', invitationExpiry: new Date().toISOString() }))
+    const uid = auth.currentUser?.uid || '';
+    const url = `${API_BASE_URL}/api/jamiahs/${jamiahId}/invite?uid=${encodeURIComponent(uid)}`;
+    fetch(url, { method: 'POST' })
+      .then(async res => {
+        if (!res.ok) throw new Error();
+        const data = await res.json();
+        setInvite({ invitationCode: data.invitationCode, invitationExpiry: data.invitationExpiry });
+      })
+      .catch(() =>
+        setInvite({ invitationCode: 'Fehler', invitationExpiry: new Date().toISOString() })
+      )
       .finally(() => setOpen(true));
   };
 


### PR DESCRIPTION
## Summary
- adjust invite URL with uid parameter
- use auth.uid for the current user
- check HTTP status before handling response
- show generic error invite on failure

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d4880a704833383215c8bb8db9ae5