### PR TITLE
Add Jamiah members endpoint

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
@@ -34,6 +34,11 @@ public class JamiahController {
         return service.findByPublicId(id);
     }
 
+    @GetMapping("/{id}/members")
+    public java.util.List<com.example.backend.UserProfile> members(@PathVariable String id) {
+        return service.getMembers(id);
+    }
+
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public JamiahDto create(

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
@@ -202,6 +202,16 @@ public class JamiahService {
         return mapper.toDto(entity);
     }
 
+    /**
+     * Retrieve all members of the Jamiah identified by the public id.
+     */
+    public java.util.List<com.example.backend.UserProfile> getMembers(String publicId) {
+        Jamiah base = getByPublicId(publicId);
+        Jamiah withMembers = repository.findWithMembersById(base.getId())
+                .orElse(base);
+        return new java.util.ArrayList<>(withMembers.getMembers());
+    }
+
     public void delete(String publicId, String uid) {
         Jamiah entity = getByPublicId(publicId);
         ensureOwner(entity, uid);

--- a/backend/src/test/java/com/example/backend/jamiah/JamiahServiceTest.java
+++ b/backend/src/test/java/com/example/backend/jamiah/JamiahServiceTest.java
@@ -303,4 +303,33 @@ class JamiahServiceTest {
         assertEquals(1, repository.countMembers(repository.findAll().get(0).getId()));
         assertEquals(created.getId(), joined.getId());
     }
+
+    @Test
+    void getMembersReturnsAllMembers() {
+        JamiahDto dto = new JamiahDto();
+        dto.setName("MemberList");
+        dto.setIsPublic(true);
+        dto.setMaxGroupSize(3);
+        dto.setCycleCount(1);
+        dto.setRateAmount(new BigDecimal("5"));
+        dto.setRateInterval(RateInterval.MONTHLY);
+        dto.setStartDate(LocalDate.now());
+
+        JamiahDto created = service.create(dto);
+
+        UserProfile u1 = new UserProfile();
+        u1.setUsername("user1");
+        u1.setUid("uid1");
+        userRepository.save(u1);
+        service.joinPublic(created.getId().toString(), "uid1");
+
+        UserProfile u2 = new UserProfile();
+        u2.setUsername("user2");
+        u2.setUid("uid2");
+        userRepository.save(u2);
+        service.joinPublic(created.getId().toString(), "uid2");
+
+        java.util.List<UserProfile> members = service.getMembers(created.getId().toString());
+        assertEquals(2, members.size());
+    }
 }

--- a/frontend/src/pages/memebers/members.tsx
+++ b/frontend/src/pages/memebers/members.tsx
@@ -1,5 +1,6 @@
 
 import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import {
   Box,
   Typography,
@@ -25,15 +26,17 @@ interface Member {
 }
 
 export const Members = () => {
+  const { groupId } = useParams();
   const [isAdminView, setIsAdminView] = useState(true);
   const [members, setMembers] = useState<Member[]>([]);
 
   useEffect(() => {
-    fetch(`${API_BASE_URL}/api/userProfiles`)
+    if (!groupId) return;
+    fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/members`)
       .then(res => res.json())
       .then(setMembers)
       .catch(() => setMembers([]));
-  }, []);
+  }, [groupId]);
 
   return (
       <Box p={4}>


### PR DESCRIPTION
## Summary
- expose `/api/jamiahs/{id}/members` to list all members in a Jamiah
- fetch members of the selected Jamiah in the frontend
- cover new service method with unit test

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687d49d92d3c8333a549b179cd3ec9dc