### PR TITLE
Add start cycle button to group list and dashboard

### DIFF
--- a/frontend/src/pages/groups/groups.tsx
+++ b/frontend/src/pages/groups/groups.tsx
@@ -47,6 +47,7 @@ import { API_BASE_URL } from '../../constants/api';
 import { auth } from '../../firebase_config';
 import { useAuth } from '../../context/AuthContext';
 import { GenerateInviteButton } from '../../components/jamiah/GenerateInviteButton';
+import { StartCycleButton } from '../../components/jamiah/StartCycleButton';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '../../routing/routes';
 import { motion } from 'framer-motion';
@@ -316,7 +317,13 @@ export const Groups = () => {
                         {!group.isPublic && group.id && (
                           <GenerateInviteButton jamiahId={group.id} />
                         )}
-                      </CardActions>
+                        {group.ownerId === user?.uid && !group.startDate && group.id && (
+                          <StartCycleButton
+                            jamiahId={group.id}
+                            onStarted={() => setGroups(gs => gs.map(g => g.id === group.id ? { ...g, startDate: new Date().toISOString() } : g))}
+                          />
+                        )}
+                     </CardActions>
                     </Card>
                   </motion.div>
                 </Grid>


### PR DESCRIPTION
## Summary
- fetch jamiah data in dashboard page and show cycle start button if owner
- allow starting cycle directly from group cards

## Testing
- `npm test --prefix frontend -- --watchAll=false --passWithNoTests`
- `./backend/mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687d52f0052483338f66d536ad72cf20