### PR TITLE
Fix theme export for compatibility

### DIFF
--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,5 +1,10 @@
 import { createTheme } from '@mui/material/styles';
 
+/**
+ * Create the MUI theme used across the application. Older parts of the code
+ * expect a `buildTheme` export, so we expose both `getTheme` and
+ * `buildTheme` as aliases to maintain backwards compatibility.
+ */
 export const getTheme = (darkMode: boolean) =>
   createTheme({
     palette: {
@@ -56,3 +61,7 @@ export const getTheme = (darkMode: boolean) =>
       },
     },
   });
+
+// Temporary alias for compatibility with older imports. Can be removed once all
+// usages have been migrated to `getTheme`.
+export const buildTheme = getTheme;


### PR DESCRIPTION
## Summary
- re-export `buildTheme` from `theme.ts` so older imports still work

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6884e697aebc83339b4239783633a5d0