### PR TITLE
Add email/password registration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import {Navigate, Route, Routes} from "react-router-dom";
 
 import {Landing} from "./pages/landing/landing";
 import {LoginForm} from "./pages/authentication/sign-in";
+import {SignUpForm} from "./pages/authentication/sign-up";
 import {ForgotPassword} from "./pages/authentication/forgot-password";
 import {RiskOverview} from "./pages/risk-overview/risk-overview";
 import {Layout} from "./components/layout/layout";
@@ -42,6 +43,7 @@ function App() {
             <Routes>
                 <Route path="/" element={<Landing />} />
                 <Route path={`/${ROUTES.SIGN_IN}`} element={<LoginForm />} />
+                <Route path={`/${ROUTES.SIGN_UP}`} element={<SignUpForm />} />
                 <Route path={`/${ROUTES.FORGOT_PASSWORD}`} element={<ForgotPassword />} />
                 <Route path="/verify-email" element={<VerifyEmail />} />
 

--- a/frontend/src/pages/authentication/sign-in.tsx
+++ b/frontend/src/pages/authentication/sign-in.tsx
@@ -1,15 +1,18 @@
 import React, { useState } from "react";
-import { Box, Button, Typography, Snackbar, Alert, CircularProgress } from "@mui/material";
+import { Box, Button, Typography, Snackbar, Alert, CircularProgress, TextField } from "@mui/material";
 import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
 import { auth } from "../../firebase_config";
 import { useNavigate } from "react-router-dom";
 import { ROUTES } from "../../routing/routes";
 import { API_BASE_URL } from "../../constants/api";
+import { signInWithEmail } from "../../firebase/firebase-service";
 
 export const LoginForm: React.FC = () => {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const navigate = useNavigate();
 
   const handleSnackbarClose = () => setSnackbarOpen(false);
@@ -19,6 +22,28 @@ export const LoginForm: React.FC = () => {
     setSnackbarOpen(true);
   };
 
+  const handleEmailSignIn = async () => {
+    setLoading(true);
+    try {
+      const user = await signInWithEmail(email, password);
+      if (!user) {
+        showError("Anmeldung fehlgeschlagen.");
+      } else {
+        const resp = await fetch(`${API_BASE_URL}/api/userProfiles/uid/${user.uid}`);
+        if (resp.status === 404) {
+          navigate(`/${ROUTES.PROFILE}`);
+        } else if (resp.ok) {
+          navigate("/");
+        } else {
+          showError("Profil konnte nicht geladen werden.");
+        }
+      }
+    } catch (err) {
+      showError("Anmeldung fehlgeschlagen.");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handleGoogleSignIn = async () => {
     setLoading(true);
@@ -46,15 +71,15 @@ export const LoginForm: React.FC = () => {
         <Typography variant="h5" gutterBottom>
           Login
         </Typography>
-        <Button
-            variant="outlined"
-            fullWidth
-            onClick={handleGoogleSignIn}
-            disabled={loading}
-            startIcon={loading ? <CircularProgress size={20} /> : null}
-        >
+        <TextField label="E-Mail" fullWidth sx={{ mb: 2 }} value={email} onChange={e => setEmail(e.target.value)} />
+        <TextField label="Passwort" type="password" fullWidth sx={{ mb: 2 }} value={password} onChange={e => setPassword(e.target.value)} />
+        <Button variant="contained" fullWidth onClick={handleEmailSignIn} disabled={loading} sx={{ mb: 2 }}>
+          Einloggen
+        </Button>
+        <Button variant="outlined" fullWidth onClick={handleGoogleSignIn} disabled={loading} startIcon={loading ? <CircularProgress size={20} /> : null} sx={{ mb: 2 }}>
           Mit Google anmelden
         </Button>
+        <Button fullWidth onClick={() => navigate(`/${ROUTES.SIGN_UP}`)}>Registrieren</Button>
         <Snackbar open={snackbarOpen} autoHideDuration={6000} onClose={handleSnackbarClose}>
           <Alert severity="error" onClose={handleSnackbarClose} sx={{ width: "100%" }}>
             {errorMsg}

--- a/frontend/src/pages/authentication/sign-up.tsx
+++ b/frontend/src/pages/authentication/sign-up.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { Box, Button, TextField, Typography, Snackbar, Alert } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '../../routing/routes';
+import { signUpWithEmail } from '../../firebase/firebase-service';
+import { auth } from '../../firebase_config';
+import { API_BASE_URL } from '../../constants/api';
+
+export const SignUpForm: React.FC = () => {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({
+    email: '',
+    password: '',
+    username: '',
+    firstName: '',
+    lastName: ''
+  });
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    const failed = await signUpWithEmail(formData.email, formData.password);
+    if (!failed && auth.currentUser) {
+      await fetch(`${API_BASE_URL}/api/userProfiles`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          uid: auth.currentUser.uid,
+          username: formData.username,
+          firstName: formData.firstName,
+          lastName: formData.lastName
+        })
+      });
+      navigate('/');
+    } else {
+      setMessage('Registrierung fehlgeschlagen.');
+      setOpen(true);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ mt: 3, px: 2, maxWidth: 400, mx: 'auto' }}>
+      <Typography variant="h5" gutterBottom>Registrieren</Typography>
+      <TextField label="E-Mail" name="email" type="email" fullWidth required sx={{ mb: 2 }}
+                 value={formData.email} onChange={handleChange} />
+      <TextField label="Passwort" name="password" type="password" fullWidth required sx={{ mb: 2 }}
+                 value={formData.password} onChange={handleChange} />
+      <TextField label="Benutzername" name="username" fullWidth required sx={{ mb: 2 }}
+                 value={formData.username} onChange={handleChange} />
+      <TextField label="Vorname" name="firstName" fullWidth sx={{ mb: 2 }}
+                 value={formData.firstName} onChange={handleChange} />
+      <TextField label="Nachname" name="lastName" fullWidth sx={{ mb: 2 }}
+                 value={formData.lastName} onChange={handleChange} />
+      <Button type="submit" variant="contained" fullWidth disabled={loading} sx={{ mb: 2 }}>
+        Konto erstellen
+      </Button>
+      <Button fullWidth onClick={() => navigate(`/${ROUTES.SIGN_IN}`)}>Zum Login</Button>
+      <Snackbar open={open} autoHideDuration={6000} onClose={() => setOpen(false)}>
+        <Alert severity="error" onClose={() => setOpen(false)} sx={{ width: '100%' }}>
+          {message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+};

--- a/frontend/src/routing/routes.ts
+++ b/frontend/src/routing/routes.ts
@@ -1,5 +1,6 @@
 export const ROUTES = {
     SIGN_IN: 'sign-in',
+    SIGN_UP: 'sign-up',
     FORGOT_PASSWORD: 'forgot-password',
     ABOUT: 'about',
     CHAT: 'chat',


### PR DESCRIPTION
## Summary
- allow login via email/password in addition to Google
- new sign-up form creates Firebase account and stores profile data
- add route for registration

## Testing
- `npm test --silent`
- `./mvnw -q test` *(fails: Could not resolve Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68865f5aca1883339f30d9a721c63bef