### PR TITLE
Fix hero video looping

### DIFF
--- a/frontend/src/pages/landing/landing.tsx
+++ b/frontend/src/pages/landing/landing.tsx
@@ -38,7 +38,7 @@ export const Landing = () => {
               muted
               playsInline
               preload="auto"
-              onEnded={(e) => e.currentTarget.pause()}
+              loop
               style={{
                 width: "100%",
                 height: "100%",


### PR DESCRIPTION
## Summary
- loop landing page hero video

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `./mvnw test` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68869b6456c48333aba17d7a3316df65