### PR TITLE
Rename Jamiah branding to Mansa

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,7 +1,7 @@
-# XRisk Frontend
+# Mansa Frontend
 
 ## General
-This is the frontend for the XRisk project. It is built using React and Typescript.
+This is the frontend for the Mansa project. It is built using React and Typescript.
 
 
 ## Configuration

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="An intelligent platform for automated and partner-centric risk transformation">
-    <title>XRISK</title>
+    <title>Mansa</title>
+    <link rel="icon" type="image/png" href="../src/assests/imgs/jamiah_logo_color.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/chat/chat-messages.tsx
+++ b/frontend/src/components/chat/chat-messages.tsx
@@ -66,7 +66,7 @@ export const ChatMessages = () => {
                                                         <Box>
                                                             {message.created ? (
                                                                 <Typography variant="body2" color="grey.400" mb={1}>
-                                                                    {message.uid === CHATBOT_UID ? "XRisk-Chabot" : otherChatMemberName},{' '}
+                                                                    {message.uid === CHATBOT_UID ? "Mansa-Chatbot" : otherChatMemberName},{' '}
                                                                     {formatLastActivity(message.created)}
                                                                 </Typography>
                                                             ) : null}

--- a/frontend/src/components/chat/chat-sender.tsx
+++ b/frontend/src/components/chat/chat-sender.tsx
@@ -97,9 +97,9 @@ export const ChatSender = () => {
             stream: false,
         });
 
-        const xRiskChatbotResponse: string = response.choices[0]?.message?.content || "";
+        const mansaChatbotResponse: string = response.choices[0]?.message?.content || "";
 
-        if (!xRiskChatbotResponse) {
+        if (!mansaChatbotResponse) {
             console.error("No response from OpenAI:", response);
             return;
         }
@@ -109,7 +109,7 @@ export const ChatSender = () => {
             created: new Date().toISOString(),
             type: MessageTypeEnum.TEXT,
             uid: CHATBOT_UID,
-            content: xRiskChatbotResponse,
+            content: mansaChatbotResponse,
             read: false,
             prompt: prompt
         }

--- a/frontend/src/components/chat/chatbot.ts
+++ b/frontend/src/components/chat/chatbot.ts
@@ -7,7 +7,7 @@ export class Chatbot {
     constructor(risk: Risk | undefined, messages: ChatMessage[]) {
         this.basePrompt = "\"\"\"\n" +
             "           Szenario:\n" +
-            "           Stell dir vor, du bist ein Chatbot (xRisk Chatbot), der die Konversation zwischen jemandem moderiert, der sich gegen ein x-beliebiges Risiko absichern will (Risikogeber) und einem Investor (Risikonehmer), der das Risiko gegen eine Gebühr übernehmen möchte.\\s\n" +
+            "           Stell dir vor, du bist ein Chatbot (Mansa Chatbot), der die Konversation zwischen jemandem moderiert, der sich gegen ein x-beliebiges Risiko absichern will (Risikogeber) und einem Investor (Risikonehmer), der das Risiko gegen eine Gebühr übernehmen möchte.\\s\n" +
             "           Der Risikonehmer (RN) wird im Schadensfall eine festgelegte Summe an den Risikogeber (RG) auszahlen.\n" +
             "           Du bekommst einen Gesprächsverlauf (bisherige Verhandlung) von Risikogeber UND Risikonehmer als Input.\n" +
             "           \\s\n" +

--- a/frontend/src/components/layout/footer.tsx
+++ b/frontend/src/components/layout/footer.tsx
@@ -10,7 +10,7 @@ export const Footer = () => {
         <React.Fragment>
             <Grid container style={{backgroundColor: "#1F271B", padding: "40px 80px", marginTop: "auto", width: "100%"}}>
                 <Grid size={2}>
-                    <img src={Logo} style={{width: "60px", height: "50px"}} alt="logo"/>
+                    <img src={Logo} style={{width: "80px", height: "70px"}} alt="logo"/>
                 </Grid>
                 <Grid size={2}>
                     <Typography variant="h6" color="white">Product</Typography>

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -60,7 +60,7 @@ export function Header() {
                     <Box
                         onClick={() => navigate('/')}
                         component="img"
-                        sx={{maxWidth: '50px', display: {xs: 'none', md: 'flex'}, mr: 6, cursor: 'pointer'}}
+                        sx={{maxWidth: '80px', display: {xs: 'none', md: 'flex'}, mr: 6, cursor: 'pointer'}}
                         src={Logo}/>
 
                     <Box sx={{flexGrow: 1, display: {xs: 'flex', md: 'none'}}}>

--- a/frontend/src/constants/chatbot.ts
+++ b/frontend/src/constants/chatbot.ts
@@ -1,1 +1,1 @@
-export const CHATBOT_UID = "XRiskChatbot";
+export const CHATBOT_UID = "MansaChatbot";

--- a/frontend/src/pages/about/about.tsx
+++ b/frontend/src/pages/about/about.tsx
@@ -10,11 +10,11 @@ export const About = () => {
   return (
       <Box p={{ xs: 2, md: 6 }}>
         <Typography variant="h3" fontWeight="bold" gutterBottom sx={{ color: theme.palette.primary.main }}>
-          Über Jamiah
+          Über Mansa
         </Typography>
 
         <Typography variant="body1" fontSize={18} gutterBottom sx={{ maxWidth: '800px' }}>
-          Jamiah ist die digitale Plattform für muslimische Gemeinschaften, die Organisation, Finanzen und Kommunikation
+          Mansa ist die digitale Plattform für muslimische Gemeinschaften, die Organisation, Finanzen und Kommunikation
           intelligent vereint. Egal ob Moschee-Verein, Spenden-Initiative oder Nachbarschafts-Jamiah –
           wir digitalisieren den Zusammenhalt.
         </Typography>
@@ -29,7 +29,7 @@ export const About = () => {
               </Avatar>
               <Typography variant="h6" fontWeight="bold">Unsere Mission</Typography>
               <Typography variant="body2" mt={1}>
-                Jamiah bringt Struktur, Transparenz und Effizienz in deine Gemeinschaft – mit Fokus auf Usability und Vertrauen.
+                Mansa bringt Struktur, Transparenz und Effizienz in deine Gemeinschaft – mit Fokus auf Usability und Vertrauen.
               </Typography>
             </Paper>
           </Grid>
@@ -53,7 +53,7 @@ export const About = () => {
               </Avatar>
               <Typography variant="h6" fontWeight="bold">Sicher & DSGVO-konform</Typography>
               <Typography variant="body2" mt={1}>
-                Deine Daten gehören dir. Jamiah schützt Informationen nach höchsten Sicherheitsstandards.
+                Deine Daten gehören dir. Mansa schützt Informationen nach höchsten Sicherheitsstandards.
               </Typography>
             </Paper>
           </Grid>
@@ -64,7 +64,7 @@ export const About = () => {
             Kontakt & Kooperation
           </Typography>
           <Typography variant="body1" sx={{ maxWidth: '700px' }}>
-            Du möchtest Jamiah in deiner Gemeinde einsetzen, Feedback geben oder mitentwickeln?
+            Du möchtest Mansa in deiner Gemeinde einsetzen, Feedback geben oder mitentwickeln?
             Wir freuen uns über deine Nachricht.
           </Typography>
         </Box>

--- a/frontend/src/pages/landing/landing.tsx
+++ b/frontend/src/pages/landing/landing.tsx
@@ -67,7 +67,7 @@ export const Landing = () => {
                     }}
                 >
                   <Typography variant="h3" fontWeight="bold" gutterBottom>
-                    Jamiah – Die digitale Gemeinschaft
+                    Mansa – Die Jamiah-Plattform
                   </Typography>
                   <Typography variant="h5" maxWidth="600px">
                     Gemeinsam. Transparent. Digital. – Deine Jamiah mit einem Klick organisiert.
@@ -85,13 +85,13 @@ export const Landing = () => {
         {/* PROBLEM / LÖSUNG */}
         <Container maxWidth="md" sx={{ py: 10 }}>
           <Typography variant="h4" gutterBottom color="primary.main">
-            Warum Jamiah?
+            Warum Mansa?
           </Typography>
           <Typography variant="body1" sx={{ fontSize: "1.1rem" }}>
             Papierformulare, manuelle Buchhaltung und fehlende Transparenz sind Vergangenheit.
           </Typography>
           <Typography variant="body1" sx={{ mt: 2, fontSize: "1.1rem" }}>
-            Mit <strong>Jamiah</strong> digitalisierst du deine Gemeinschaft: Mitgliederverwaltung, Beiträge,
+            Mit <strong>Mansa</strong> digitalisierst du deine Gemeinschaft: Mitgliederverwaltung, Beiträge,
             Abstimmungen und Kommunikation – alles in einer Plattform.
           </Typography>
         </Container>

--- a/frontend/src/pages/onboarding/onboarding.tsx
+++ b/frontend/src/pages/onboarding/onboarding.tsx
@@ -18,14 +18,14 @@ export const Onboarding = () => {
     if (activeStep < steps.length - 1) {
       setActiveStep(prev => prev + 1);
     } else {
-      alert('Willkommen bei Jamiah! 🎉');
+      alert('Willkommen bei Mansa! 🎉');
     }
   };
 
   return (
       <Box p={4}>
         <Typography variant="h4" fontWeight="bold" gutterBottom>
-          Willkommen bei Jamiah 👋
+          Willkommen bei Mansa 👋
         </Typography>
 
         <Paper sx={{ p: 3, mt: 2 }}>


### PR DESCRIPTION
## Summary
- change page title to Mansa and add favicon
- enlarge header and footer logos
- rename Jamiah branding to Mansa on landing, about and onboarding pages
- update chatbot name to Mansa
- use existing jamiah_logo_color.png via symlink
- remove duplicate public logo and reference asset directly

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68871fbab3808333b5e55e824f0010cd