### PR TITLE
Add PayPal payment tracking and voting system

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
@@ -69,12 +69,22 @@ public class JamiahController {
         return service.startCycle(id, uid);
     }
 
+    @GetMapping("/{id}/cycles")
+    public java.util.List<JamiahCycle> cycles(@PathVariable String id) {
+        return service.getCycles(id);
+    }
+
     @PostMapping("/{id}/cycles/{cycleId}/pay")
     public JamiahPayment pay(@PathVariable String id,
                              @PathVariable Long cycleId,
                              @RequestParam String uid,
                              @RequestParam BigDecimal amount) {
         return service.recordPayment(cycleId, uid, amount);
+    }
+
+    @GetMapping("/{id}/cycles/{cycleId}/payments")
+    public java.util.List<JamiahPayment> payments(@PathVariable String id, @PathVariable Long cycleId) {
+        return service.getPayments(cycleId);
     }
 
     @PostMapping("/join")

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahCycleRepository.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahCycleRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JamiahCycleRepository extends JpaRepository<JamiahCycle, Long> {
     long countByJamiahId(Long jamiahId);
+    java.util.List<JamiahCycle> findByJamiahId(Long jamiahId);
 }

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahPaymentRepository.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahPaymentRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JamiahPaymentRepository extends JpaRepository<JamiahPayment, Long> {
     long countByCycleId(Long cycleId);
+    java.util.List<JamiahPayment> findByCycleId(Long cycleId);
 }

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
@@ -278,6 +278,11 @@ public class JamiahService {
         return cycleRepository.save(cycle);
     }
 
+    public java.util.List<JamiahCycle> getCycles(String jamiahPublicId) {
+        Jamiah jamiah = getByPublicId(jamiahPublicId);
+        return cycleRepository.findByJamiahId(jamiah.getId());
+    }
+
     public JamiahPayment recordPayment(Long cycleId, String uid, BigDecimal amount) {
         JamiahCycle cycle = cycleRepository.findById(cycleId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
@@ -297,6 +302,10 @@ public class JamiahService {
             cycleRepository.save(cycle);
         }
         return saved;
+    }
+
+    public java.util.List<JamiahPayment> getPayments(Long cycleId) {
+        return paymentRepository.findByCycleId(cycleId);
     }
 
     void validateParameters(JamiahDto dto) {

--- a/backend/src/main/java/com/example/backend/vote/Vote.java
+++ b/backend/src/main/java/com/example/backend/vote/Vote.java
@@ -1,0 +1,35 @@
+package com.example.backend.vote;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Data
+@Entity
+@Table(name = "votes")
+public class Vote {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @ElementCollection
+    @CollectionTable(name = "vote_options", joinColumns = @JoinColumn(name = "vote_id"))
+    @Column(name = "option_value")
+    private List<String> options = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(name = "vote_ballots", joinColumns = @JoinColumn(name = "vote_id"))
+    @MapKeyColumn(name = "user_id")
+    @Column(name = "choice")
+    private Map<String, String> ballots = new HashMap<>();
+
+    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime expiresAt;
+
+    private Boolean closed = false;
+    private String result;
+}

--- a/backend/src/main/java/com/example/backend/vote/VoteController.java
+++ b/backend/src/main/java/com/example/backend/vote/VoteController.java
@@ -1,0 +1,43 @@
+package com.example.backend.vote;
+
+import lombok.Data;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/votes")
+public class VoteController {
+    private final VoteService service;
+
+    public VoteController(VoteService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<Vote> listVotes() {
+        return service.getVotes();
+    }
+
+    @PostMapping
+    public Vote create(@RequestBody CreateVoteRequest request) {
+        return service.createVote(request.getTitle(), request.getOptions());
+    }
+
+    @PostMapping("/{id}/vote")
+    public Vote vote(@PathVariable Long id, @RequestBody CastVoteRequest request) {
+        return service.castVote(id, request.getUserId(), request.getChoice());
+    }
+
+    @Data
+    static class CreateVoteRequest {
+        private String title;
+        private List<String> options;
+    }
+
+    @Data
+    static class CastVoteRequest {
+        private String userId;
+        private String choice;
+    }
+}

--- a/backend/src/main/java/com/example/backend/vote/VoteRepository.java
+++ b/backend/src/main/java/com/example/backend/vote/VoteRepository.java
@@ -1,0 +1,6 @@
+package com.example.backend.vote;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+}

--- a/backend/src/main/java/com/example/backend/vote/VoteService.java
+++ b/backend/src/main/java/com/example/backend/vote/VoteService.java
@@ -1,0 +1,55 @@
+package com.example.backend.vote;
+
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class VoteService {
+    private final VoteRepository repository;
+
+    public VoteService(VoteRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<Vote> getVotes() {
+        List<Vote> votes = repository.findAll();
+        votes.forEach(this::checkExpiry);
+        return votes;
+    }
+
+    public Vote createVote(String title, List<String> options) {
+        Vote vote = new Vote();
+        vote.setTitle(title);
+        vote.setOptions(options);
+        vote.setCreatedAt(LocalDateTime.now());
+        vote.setExpiresAt(LocalDateTime.now().plusDays(5));
+        return repository.save(vote);
+    }
+
+    public Vote castVote(Long id, String userId, String choice) {
+        Vote vote = repository.findById(id).orElseThrow();
+        checkExpiry(vote);
+        if (Boolean.TRUE.equals(vote.getClosed())) {
+            throw new IllegalStateException("Vote already closed");
+        }
+        vote.getBallots().put(userId, choice);
+        return repository.save(vote);
+    }
+
+    private void checkExpiry(Vote vote) {
+        if (Boolean.TRUE.equals(vote.getClosed())) return;
+        if (vote.getExpiresAt() != null && LocalDateTime.now().isAfter(vote.getExpiresAt())) {
+            boolean unanimous = !vote.getBallots().isEmpty() &&
+                    vote.getBallots().values().stream().distinct().count() == 1;
+            vote.setClosed(true);
+            if (unanimous) {
+                vote.setResult(vote.getBallots().values().stream().findFirst().orElse(null));
+            } else {
+                vote.setResult("REJECTED");
+            }
+            repository.save(vote);
+        }
+    }
+}

--- a/frontend/src/pages/dashboard/dashboard.tsx
+++ b/frontend/src/pages/dashboard/dashboard.tsx
@@ -18,24 +18,17 @@ import { selectName } from '../../store/slices/user-profile';
 import { JamiahSettings } from '../../components/jamiah/JamiahSettings';
 import { Jamiah } from '../../models/Jamiah';
 import { API_BASE_URL } from '../../constants/api';
-import { StartCycleButton } from '../../components/jamiah/StartCycleButton';
-import { useAuth } from '../../context/AuthContext';
 
 export const Dashboard = () => {
   const { groupId } = useParams();
   const userName = useSelector(selectName);
-  const { user } = useAuth();
   const [jamiah, setJamiah] = useState<Jamiah | null>(null);
-  const [cycleStarted, setCycleStarted] = useState(false);
 
   useEffect(() => {
     if (!groupId) return;
     fetch(`${API_BASE_URL}/api/jamiahs/${groupId}`)
       .then(res => res.json())
-      .then(data => {
-        setJamiah(data);
-        if (data.startDate) setCycleStarted(true);
-      })
+      .then(data => setJamiah(data))
       .catch(() => setJamiah(null));
   }, [groupId]);
 
@@ -113,17 +106,13 @@ export const Dashboard = () => {
           ))}
         </Grid>
 
-        {jamiah && user?.uid === jamiah.ownerId && (
-          <Box mb={2}>
-            <StartCycleButton
-              jamiahId={jamiah.id as string}
-              onStarted={() => setCycleStarted(true)}
-            />
-            {cycleStarted && (
-              <Typography variant="body2" mt={1}>
-                Aktiver Zyklus läuft
+        {jamiah && (
+          <Box mb={4}>
+            <Paper sx={{ p: 2, textAlign: 'center' }}>
+              <Typography variant="h6">
+                {jamiah.startDate ? '🟢 Zyklus läuft' : '⏸️ Zyklus noch nicht gestartet'}
               </Typography>
-            )}
+            </Paper>
           </Box>
         )}
 

--- a/frontend/src/pages/payments/payments.tsx
+++ b/frontend/src/pages/payments/payments.tsx
@@ -1,59 +1,158 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Box, Typography, Paper, List, ListItem, ListItemText, Button,
-  Switch, FormControlLabel
+  Switch, FormControlLabel, TextField, MenuItem
 } from '@mui/material';
 import EuroIcon from '@mui/icons-material/Euro';
 import { API_BASE_URL } from '../../constants/api';
 import { auth } from '../../firebase_config';
 
-export const Payments = () => {
-  const [isAdminView, setIsAdminView] = useState(true);
-  const members = [
-    { uid: 'u1', name: 'Amina Yusuf' },
-    { uid: 'u2', name: 'Ali Khan' },
-  ];
+interface Member {
+  uid: string;
+  username: string;
+  firstName?: string;
+  lastName?: string;
+}
 
-  const handlePay = (uid: string) => {
-    const groupId = (window.location.pathname.split('/')[2]);
-    const cycleId = 1; // simplified demo
-    fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/cycles/${cycleId}/pay?uid=${encodeURIComponent(uid)}&amount=50`, { method: 'POST' });
+interface Payment {
+  user: { uid: string; };
+  paidAt: string;
+}
+
+interface Cycle {
+  id: number;
+  cycleNumber: number;
+  startDate: string;
+  completed: boolean;
+}
+
+export const Payments = () => {
+  const [isAdminView, setIsAdminView] = useState(false);
+  const [isOwner, setIsOwner] = useState(false);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [payments, setPayments] = useState<Payment[]>([]);
+  const [cycles, setCycles] = useState<Cycle[]>([]);
+  const [selectedCycle, setSelectedCycle] = useState<number | null>(null);
+  const [amount, setAmount] = useState<number>(50);
+
+  const groupId = window.location.pathname.split('/')[2];
+  const currentUid = auth.currentUser?.uid;
+
+  useEffect(() => {
+    fetch(`${API_BASE_URL}/api/jamiahs/${groupId}`)
+      .then(r => r.json())
+      .then(data => {
+        setAmount(data.rateAmount || 50);
+        const owner = data.ownerId === currentUid;
+        setIsOwner(owner);
+        setIsAdminView(owner);
+      });
+
+    fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/members`)
+      .then(r => r.json())
+      .then(data => setMembers(data));
+
+    fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/cycles`)
+      .then(r => r.json())
+      .then(data => {
+        setCycles(data);
+        if (data.length > 0) {
+          setSelectedCycle(data[data.length - 1].id);
+        }
+      });
+  }, [groupId, currentUid]);
+
+  const fetchPayments = (cycleId: number) => {
+    fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/cycles/${cycleId}/payments`)
+      .then(r => r.json())
+      .then(data => setPayments(data));
+  };
+
+  useEffect(() => {
+    if (selectedCycle !== null) {
+      fetchPayments(selectedCycle);
+    }
+  }, [groupId, selectedCycle]);
+
+  const handlePay = () => {
+    const link = `https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=student.abdelkarim@gmail.com&amount=${amount}&currency_code=EUR`;
+    window.open(link, '_blank');
+  };
+
+  const handleConfirm = (uid: string) => {
+    if (!selectedCycle) return;
+    fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/cycles/${selectedCycle}/pay?uid=${encodeURIComponent(uid)}&amount=${amount}`, { method: 'POST' })
+      .then(() => fetchPayments(selectedCycle));
+  };
+
+  const renderMemberRow = (m: Member) => {
+    const payment = payments.find(p => p.user.uid === m.uid);
+    const name = m.firstName || m.lastName ? `${m.firstName || ''} ${m.lastName || ''}`.trim() : m.username;
+    return (
+      <ListItem key={m.uid} secondaryAction={
+        payment ? (
+          <Typography variant="body2">{new Date(payment.paidAt).toLocaleDateString()}</Typography>
+        ) : (
+          <Button size="small" variant="outlined" onClick={() => handleConfirm(m.uid)}>Bestätigen</Button>
+        )
+      }>
+        <ListItemText primary={name} />
+      </ListItem>
+    );
   };
 
   return (
       <Box p={4}>
         <Box display="flex" justifyContent="space-between" alignItems="center" mb={4}>
           <Typography variant="h4" fontWeight="bold">Zahlungsübersicht</Typography>
-          <FormControlLabel
-              control={
-                <Switch
+          <Box display="flex" alignItems="center" gap={2}>
+            {cycles.length > 0 && (
+              <TextField
+                select
+                label="Zyklus"
+                value={selectedCycle ?? ''}
+                onChange={e => setSelectedCycle(Number(e.target.value))}
+                size="small"
+              >
+                {cycles.map(c => (
+                  <MenuItem key={c.id} value={c.id}>Zyklus {c.cycleNumber}</MenuItem>
+                ))}
+              </TextField>
+            )}
+            {isOwner && (
+              <FormControlLabel
+                control={
+                  <Switch
                     checked={isAdminView}
                     onChange={() => setIsAdminView(!isAdminView)}
-                />
-              }
-              label={isAdminView ? "Admin-Modus" : "Mitgliedsansicht"}
-          />
+                  />
+                }
+                label={isAdminView ? "Admin-Modus" : "Mitgliedsansicht"}
+              />
+            )}
+          </Box>
         </Box>
 
-        {isAdminView && (
-            <Box mb={3}>
-              <Button variant="contained" startIcon={<EuroIcon />}>
-                Manuelle Zahlung verbuchen
-              </Button>
-            </Box>
-        )}
+        <Box mb={3}>
+          <Button variant="contained" startIcon={<EuroIcon />} onClick={handlePay}>
+            Beitrag bezahlen
+          </Button>
+          <Button sx={{ ml: 2 }} variant="outlined" onClick={() => handleConfirm(currentUid || '')}>Zahlung bestätigen</Button>
+        </Box>
 
-        <Paper sx={{ p: 2 }}>
-          <List>
-            {members.map(m => (
-              <ListItem key={m.uid} secondaryAction={
-                <Button size="small" variant="outlined" onClick={() => handlePay(m.uid)}>Bezahlt</Button>
-              }>
-                <ListItemText primary={m.name} />
-              </ListItem>
-            ))}
-          </List>
-        </Paper>
+        {isAdminView ? (
+          <Paper sx={{ p: 2 }}>
+            <List>
+              {members.map(renderMemberRow)}
+            </List>
+          </Paper>
+        ) : (
+          <Typography variant="body2">
+            {payments.find(p => p.user.uid === currentUid)
+              ? `Bezahlt am ${new Date((payments.find(p => p.user.uid === currentUid) as Payment).paidAt).toLocaleDateString()}`
+              : 'Noch nicht bezahlt'}
+          </Typography>
+        )}
       </Box>
   );
 };

--- a/frontend/src/pages/votes/votes.tsx
+++ b/frontend/src/pages/votes/votes.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Box, Typography, Card, CardContent, Button, Stack, Dialog, DialogTitle,
   DialogContent, DialogActions, TextField, Divider
@@ -6,24 +6,66 @@ import {
 import HowToVoteIcon from '@mui/icons-material/HowToVote';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import AddIcon from '@mui/icons-material/Add';
+import { API_BASE_URL } from '../../constants/api';
+import { auth } from '../../firebase_config';
+import { useParams } from 'react-router-dom';
+import { StartCycleButton } from '../../components/jamiah/StartCycleButton';
+import { Jamiah } from '../../models/Jamiah';
+import { useAuth } from '../../context/AuthContext';
+
+interface Vote {
+  id: number;
+  title: string;
+  options: string[];
+  ballots: Record<string, string>;
+  closed: boolean;
+  result?: string;
+  expiresAt: string;
+}
 
 export const Votes = () => {
-  const [voteModalOpen, setVoteModalOpen] = React.useState(false);
-  const [detailModalOpen, setDetailModalOpen] = React.useState(false);
-  const [createModalOpen, setCreateModalOpen] = React.useState(false);
-  const [selectedVote, setSelectedVote] = React.useState<any | null>(null);
+  const [votes, setVotes] = useState<Vote[]>([]);
+  const [voteModalOpen, setVoteModalOpen] = useState(false);
+  const [detailModalOpen, setDetailModalOpen] = useState(false);
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [selectedVote, setSelectedVote] = useState<Vote | null>(null);
+  const [newTitle, setNewTitle] = useState('');
+  const [opt1, setOpt1] = useState('');
+  const [opt2, setOpt2] = useState('');
+  const [opt3, setOpt3] = useState('');
+  const [jamiah, setJamiah] = useState<Jamiah | null>(null);
+  const [cycleStarted, setCycleStarted] = useState(false);
+  const { user } = useAuth();
+  const { groupId } = useParams();
 
-  const votes = [
-    { title: 'Neue Beitragshöhe ab Juni', status: 'Läuft', options: ['40€', '45€', '50€'], result: '45€' },
-    { title: 'Anschaffung neuer Teppiche', status: 'Abgeschlossen', result: 'Ja' },
-  ];
+  const uid = auth.currentUser?.uid || '';
 
-  const handleVote = (vote: any) => {
+  const loadVotes = () => {
+    fetch(`${API_BASE_URL}/api/votes`)
+      .then(r => r.json())
+      .then(data => setVotes(data));
+  };
+
+  useEffect(() => {
+    loadVotes();
+  }, []);
+
+  useEffect(() => {
+    if (!groupId) return;
+    fetch(`${API_BASE_URL}/api/jamiahs/${groupId}`)
+      .then(r => r.json())
+      .then(data => {
+        setJamiah(data);
+        if (data.startDate) setCycleStarted(true);
+      });
+  }, [groupId]);
+
+  const handleVote = (vote: Vote) => {
     setSelectedVote(vote);
     setVoteModalOpen(true);
   };
 
-  const handleDetails = (vote: any) => {
+  const handleDetails = (vote: Vote) => {
     setSelectedVote(vote);
     setDetailModalOpen(true);
   };
@@ -32,105 +74,137 @@ export const Votes = () => {
     setCreateModalOpen(true);
   };
 
+  const submitVote = (choice: string) => {
+    if (!selectedVote) return;
+    fetch(`${API_BASE_URL}/api/votes/${selectedVote.id}/vote`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: uid, choice })
+    }).then(() => {
+      setVoteModalOpen(false);
+      loadVotes();
+    });
+  };
+
+  const saveVote = () => {
+    const options = [opt1, opt2, opt3].filter(Boolean);
+    fetch(`${API_BASE_URL}/api/votes`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: newTitle, options })
+    }).then(() => {
+      setCreateModalOpen(false);
+      setNewTitle('');
+      setOpt1('');
+      setOpt2('');
+      setOpt3('');
+      loadVotes();
+    });
+  };
+
   return (
-      <Box p={4}>
-        <Box display="flex" justifyContent="space-between" alignItems="center" mb={4}>
-          <Typography variant="h4" fontWeight="bold">Abstimmungen</Typography>
+    <Box p={4}>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={4}>
+        <Typography variant="h4" fontWeight="bold">Abstimmungen</Typography>
+        <Stack direction="row" spacing={2}>
+          {jamiah && user?.uid === jamiah.ownerId && !cycleStarted && (
+            <StartCycleButton
+              jamiahId={jamiah.id as string}
+              onStarted={() => setCycleStarted(true)}
+            />
+          )}
           <Button
-              startIcon={<AddIcon />}
-              variant="contained"
-              sx={{ textTransform: 'none' }}
-              onClick={handleCreateNew}
+            startIcon={<AddIcon />}
+            variant="contained"
+            sx={{ textTransform: 'none' }}
+            onClick={handleCreateNew}
           >
             Neue Abstimmung
           </Button>
-        </Box>
-
-        <Stack spacing={3}>
-          {votes.map((vote, i) => (
-              <Card key={i}>
-                <CardContent>
-                  <Typography variant="h6">{vote.title}</Typography>
-                  <Typography color="textSecondary">Status: {vote.status}</Typography>
-
-                  <Stack direction="row" spacing={2} sx={{ mt: 2 }}>
-                    {vote.status === 'Läuft' && (
-                        <Button variant="outlined" startIcon={<HowToVoteIcon />} onClick={() => handleVote(vote)}>
-                          Jetzt abstimmen
-                        </Button>
-                    )}
-                    <Button variant="outlined" startIcon={<VisibilityIcon />} onClick={() => handleDetails(vote)}>
-                      Details / Ergebnis
-                    </Button>
-                  </Stack>
-                </CardContent>
-              </Card>
-          ))}
         </Stack>
-
-        {/* Abstimmen Modal */}
-        <Dialog open={voteModalOpen} onClose={() => setVoteModalOpen(false)} maxWidth="xs" fullWidth>
-          <DialogTitle>Jetzt abstimmen</DialogTitle>
-          <DialogContent>
-            {selectedVote?.options?.map((opt: string, idx: number) => (
-                <Button
-                    key={idx}
-                    fullWidth
-                    sx={{ my: 1 }}
-                    variant="outlined"
-                    onClick={() => {
-                      alert(`Du hast für "${opt}" gestimmt.`);
-                      setVoteModalOpen(false);
-                    }}
-                >
-                  {opt}
-                </Button>
-            ))}
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setVoteModalOpen(false)}>Abbrechen</Button>
-          </DialogActions>
-        </Dialog>
-
-        {/* Details Modal */}
-        <Dialog open={detailModalOpen} onClose={() => setDetailModalOpen(false)} maxWidth="sm" fullWidth>
-          <DialogTitle>Abstimmungsdetails</DialogTitle>
-          <DialogContent>
-            <Typography variant="h6">{selectedVote?.title}</Typography>
-            <Divider sx={{ my: 2 }} />
-            {selectedVote?.status === 'Abgeschlossen' ? (
-                <>
-                  <Typography>Ergebnis: <b>{selectedVote?.result}</b></Typography>
-                  <Typography color="textSecondary" sx={{ mt: 1 }}>
-                    Diese Abstimmung wurde erfolgreich abgeschlossen.
-                  </Typography>
-                </>
-            ) : (
-                <Typography>Abstimmung läuft noch – bitte Stimme abgeben.</Typography>
-            )}
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setDetailModalOpen(false)}>Schließen</Button>
-          </DialogActions>
-        </Dialog>
-
-        {/* Neue Abstimmung Modal */}
-        <Dialog open={createModalOpen} onClose={() => setCreateModalOpen(false)} maxWidth="sm" fullWidth>
-          <DialogTitle>Neue Abstimmung erstellen</DialogTitle>
-          <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-            <TextField label="Titel der Abstimmung" fullWidth />
-            <TextField label="Option 1" fullWidth />
-            <TextField label="Option 2" fullWidth />
-            <TextField label="Option 3 (optional)" fullWidth />
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setCreateModalOpen(false)}>Abbrechen</Button>
-            <Button onClick={() => {
-              alert('Abstimmung gespeichert!');
-              setCreateModalOpen(false);
-            }}>Speichern</Button>
-          </DialogActions>
-        </Dialog>
       </Box>
+
+      <Stack spacing={3}>
+        {votes.map(vote => (
+          <Card key={vote.id}>
+            <CardContent>
+              <Typography variant="h6">{vote.title}</Typography>
+              <Typography color="textSecondary">
+                {vote.closed ? 'Abgeschlossen' : 'Läuft'}
+              </Typography>
+
+              <Stack direction="row" spacing={2} sx={{ mt: 2 }}>
+                {!vote.closed && (
+                  <Button variant="outlined" startIcon={<HowToVoteIcon />} onClick={() => handleVote(vote)}>
+                    Jetzt abstimmen
+                  </Button>
+                )}
+                <Button variant="outlined" startIcon={<VisibilityIcon />} onClick={() => handleDetails(vote)}>
+                  Details / Ergebnis
+                </Button>
+              </Stack>
+            </CardContent>
+          </Card>
+        ))}
+      </Stack>
+
+      {/* Abstimmen Modal */}
+      <Dialog open={voteModalOpen} onClose={() => setVoteModalOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Jetzt abstimmen</DialogTitle>
+        <DialogContent>
+          {selectedVote?.options.map((opt, idx) => (
+            <Button
+              key={idx}
+              fullWidth
+              sx={{ my: 1 }}
+              variant="outlined"
+              onClick={() => submitVote(opt)}
+            >
+              {opt}
+            </Button>
+          ))}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setVoteModalOpen(false)}>Abbrechen</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Details Modal */}
+      <Dialog open={detailModalOpen} onClose={() => setDetailModalOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Abstimmungsdetails</DialogTitle>
+        <DialogContent>
+          <Typography variant="h6">{selectedVote?.title}</Typography>
+          <Divider sx={{ my: 2 }} />
+          {selectedVote?.closed ? (
+            <>
+              <Typography>Ergebnis: <b>{selectedVote?.result || 'Abgelehnt'}</b></Typography>
+              <Typography color="textSecondary" sx={{ mt: 1 }}>
+                Diese Abstimmung wurde abgeschlossen.
+              </Typography>
+            </>
+          ) : (
+            <Typography>Abstimmung läuft noch – bitte Stimme abgeben.</Typography>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDetailModalOpen(false)}>Schließen</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Neue Abstimmung Modal */}
+      <Dialog open={createModalOpen} onClose={() => setCreateModalOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Neue Abstimmung erstellen</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField label="Titel der Abstimmung" fullWidth value={newTitle} onChange={e => setNewTitle(e.target.value)} />
+          <TextField label="Option 1" fullWidth value={opt1} onChange={e => setOpt1(e.target.value)} />
+          <TextField label="Option 2" fullWidth value={opt2} onChange={e => setOpt2(e.target.value)} />
+          <TextField label="Option 3 (optional)" fullWidth value={opt3} onChange={e => setOpt3(e.target.value)} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCreateModalOpen(false)}>Abbrechen</Button>
+          <Button onClick={saveVote}>Speichern</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
   );
 };


### PR DESCRIPTION
## Summary
- list Jamiah cycles and expose endpoint to retrieve them
- fetch payments per cycle and show admin/member views for contributions
- allow both admins and members to confirm payments with cycle selector
- add simple voting backend with endpoints to create and cast votes
- wire the votes page to backend so members can create and participate in votes
- show cycle status card on dashboard and move cycle start button to votes page

## Testing
- `CI=true npm test` *(fails: No tests found, exiting with code 1)*
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68979b2a2b548333b97e5225241cd6ad