### PR TITLE
feat: implement jamiah payout rounds

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
@@ -87,6 +87,13 @@ public class JamiahController {
         return service.getPayments(cycleId);
     }
 
+    @PostMapping("/{id}/cycles/{cycleId}/confirm-receipt")
+    public JamiahCycle confirmReceipt(@PathVariable String id,
+                                      @PathVariable Long cycleId,
+                                      @RequestParam String uid) {
+        return service.confirmReceipt(cycleId, uid);
+    }
+
     @PostMapping("/join")
     public JamiahDto join(@RequestParam String code, @RequestParam String uid) {
         return service.joinByInvitation(code, uid);

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahCycle.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahCycle.java
@@ -4,7 +4,9 @@ import jakarta.persistence.*;
 import lombok.Data;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Data
@@ -22,6 +24,23 @@ public class JamiahCycle {
     private Integer cycleNumber;
     private LocalDate startDate;
     private Boolean completed = false;
+
+    /**
+     * Order of members for the whole cycle (uids in payout order).
+     * Generated once at the beginning of the cycle and copied to subsequent rounds.
+     */
+    @ElementCollection
+    @CollectionTable(name = "jamiah_cycle_order", joinColumns = @JoinColumn(name = "cycle_id"))
+    @Column(name = "member_uid")
+    private List<String> memberOrder = new ArrayList<>();
+
+    /** Current recipient for this round. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipient_id")
+    private com.example.backend.UserProfile recipient;
+
+    /** Whether the current recipient confirmed receipt. */
+    private Boolean recipientConfirmed = false;
 
     @OneToMany(mappedBy = "cycle")
     private Set<JamiahPayment> payments = new HashSet<>();

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahPayment.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahPayment.java
@@ -25,4 +25,7 @@ public class JamiahPayment {
 
     private BigDecimal amount;
     private LocalDateTime paidAt;
+
+    /** Whether the payer confirmed the payment. */
+    private Boolean confirmed = false;
 }


### PR DESCRIPTION
## Summary
- track member order and payout recipient for each jamiah cycle
- shuffle members and auto-start next payout rounds
- show round progress and payout order on dashboard

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.0)*
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6897c7dc268083339d6ed023e6d8bedf