### PR TITLE
Add recipient and order columns to Jamiah cycles

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/JamiahCycle.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahCycle.java
@@ -32,6 +32,7 @@ public class JamiahCycle {
     @ElementCollection
     @CollectionTable(name = "jamiah_cycle_order", joinColumns = @JoinColumn(name = "cycle_id"))
     @Column(name = "member_uid")
+    @OrderColumn(name = "order_index")
     private List<String> memberOrder = new ArrayList<>();
 
     /** Current recipient for this round. */

--- a/backend/src/main/resources/db/migration/V14__add_recipient_and_order_columns.sql
+++ b/backend/src/main/resources/db/migration/V14__add_recipient_and_order_columns.sql
@@ -1,0 +1,16 @@
+ALTER TABLE jamiah_cycles
+    ADD COLUMN recipient_id BIGINT,
+    ADD COLUMN recipient_confirmed BIT;
+
+ALTER TABLE jamiah_cycles
+    ADD CONSTRAINT fk_cycle_recipient FOREIGN KEY (recipient_id) REFERENCES user_profiles(id);
+
+CREATE TABLE jamiah_cycle_order (
+    cycle_id BIGINT NOT NULL,
+    order_index INT NOT NULL,
+    member_uid VARCHAR(255),
+    CONSTRAINT fk_cycle_order_cycle FOREIGN KEY (cycle_id) REFERENCES jamiah_cycles(id)
+);
+
+ALTER TABLE jamiah_payments
+    ADD COLUMN confirmed BIT;


### PR DESCRIPTION
## Summary
- Track member order in Jamiah cycles with an indexed collection
- Add DB migration creating recipient and payment columns plus order table

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for com.example:backend:0.0.1-SNAPSHOT: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897da9a6604833386647d99f13996b4