### PR TITLE
Add jamiah start preview and payment confirmation tracking

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
@@ -65,8 +65,13 @@ public class JamiahController {
     }
 
     @PostMapping("/{id}/start")
-    public JamiahCycle start(@PathVariable String id, @RequestParam String uid) {
-        return service.startCycle(id, uid);
+    public JamiahCycle start(@PathVariable String id, @RequestParam String uid, @RequestBody StartRequest request) {
+        return service.startCycle(id, uid, request.getOrder());
+    }
+
+    @GetMapping("/{id}/start-preview")
+    public com.example.backend.jamiah.dto.StartPreviewDto preview(@PathVariable String id, @RequestParam String uid) {
+        return service.previewStart(id, uid);
     }
 
     @GetMapping("/{id}/cycles")
@@ -87,11 +92,12 @@ public class JamiahController {
         return service.getPayments(cycleId);
     }
 
-    @PostMapping("/{id}/cycles/{cycleId}/confirm-receipt")
-    public JamiahCycle confirmReceipt(@PathVariable String id,
-                                      @PathVariable Long cycleId,
-                                      @RequestParam String uid) {
-        return service.confirmReceipt(cycleId, uid);
+    @PostMapping("/{id}/cycles/{cycleId}/payments/{paymentId}/confirm-receipt")
+    public JamiahPayment confirmPaymentReceipt(@PathVariable String id,
+                                               @PathVariable Long cycleId,
+                                               @PathVariable Long paymentId,
+                                               @RequestParam String uid) {
+        return service.confirmPaymentReceipt(cycleId, paymentId, uid);
     }
 
     @PostMapping("/join")
@@ -109,5 +115,17 @@ public class JamiahController {
     public void delete(@PathVariable String id,
                        @RequestParam(required = false) String uid) {
         service.delete(id, uid);
+    }
+
+    static class StartRequest {
+        private java.util.List<String> order;
+
+        public java.util.List<String> getOrder() {
+            return order;
+        }
+
+        public void setOrder(java.util.List<String> order) {
+            this.order = order;
+        }
     }
 }

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahPayment.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahPayment.java
@@ -28,4 +28,7 @@ public class JamiahPayment {
 
     /** Whether the payer confirmed the payment. */
     private Boolean confirmed = false;
+
+    /** Whether the current recipient confirmed receiving this payment. */
+    private Boolean recipientConfirmed = false;
 }

--- a/backend/src/main/java/com/example/backend/jamiah/dto/StartPreviewDto.java
+++ b/backend/src/main/java/com/example/backend/jamiah/dto/StartPreviewDto.java
@@ -1,0 +1,23 @@
+package com.example.backend.jamiah.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+public class StartPreviewDto {
+    private List<MemberInfo> order;
+    private BigDecimal payoutPerInterval;
+    private Integer rounds;
+    private LocalDate expectedEndDate;
+
+    @Data
+    public static class MemberInfo {
+        private String uid;
+        private String username;
+        private String firstName;
+        private String lastName;
+    }
+}

--- a/backend/src/main/resources/db/migration/V15__add_recipient_confirmed_column.sql
+++ b/backend/src/main/resources/db/migration/V15__add_recipient_confirmed_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE jamiah_payments
+    ADD COLUMN recipient_confirmed BIT;

--- a/frontend/src/components/jamiah/StartCycleButton.tsx
+++ b/frontend/src/components/jamiah/StartCycleButton.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button } from '@mui/material';
+import { Button, Dialog, DialogTitle, DialogContent, DialogActions, Typography, List, ListItem, ListItemText } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { API_BASE_URL } from '../../constants/api';
 import { auth } from '../../firebase_config';
@@ -9,22 +9,79 @@ interface Props {
   onStarted?: () => void;
 }
 
+interface PreviewMember {
+  uid: string;
+  username: string;
+  firstName?: string;
+  lastName?: string;
+}
+
+interface StartPreview {
+  order: PreviewMember[];
+  payoutPerInterval: number;
+  rounds: number;
+  expectedEndDate: string;
+}
+
 export const StartCycleButton: React.FC<Props> = ({ jamiahId, onStarted }) => {
   const [loading, setLoading] = useState(false);
+  const [preview, setPreview] = useState<StartPreview | null>(null);
+  const [open, setOpen] = useState(false);
 
   const handleClick = () => {
     const uid = auth.currentUser?.uid || '';
     setLoading(true);
-    fetch(`${API_BASE_URL}/api/jamiahs/${jamiahId}/start?uid=${encodeURIComponent(uid)}`, {
-      method: 'POST'
-    })
-      .then(() => onStarted?.())
+    fetch(`${API_BASE_URL}/api/jamiahs/${jamiahId}/start-preview?uid=${encodeURIComponent(uid)}`)
+      .then(r => r.json())
+      .then(data => {
+        setPreview(data);
+        setOpen(true);
+      })
       .finally(() => setLoading(false));
   };
 
+  const handleStart = () => {
+    if (!preview) return;
+    const uid = auth.currentUser?.uid || '';
+    fetch(`${API_BASE_URL}/api/jamiahs/${jamiahId}/start?uid=${encodeURIComponent(uid)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ order: preview.order.map(m => m.uid) })
+    }).then(() => {
+      setOpen(false);
+      onStarted?.();
+    });
+  };
+
   return (
-    <Button variant="contained" startIcon={<PlayArrowIcon />} onClick={handleClick} disabled={loading}>
-      Zyklus starten
-    </Button>
+    <>
+      <Button variant="contained" startIcon={<PlayArrowIcon />} onClick={handleClick} disabled={loading}>
+        Jamiah starten
+      </Button>
+      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Jamiah starten</DialogTitle>
+        <DialogContent>
+          {preview && (
+            <>
+              <Typography variant="subtitle1" gutterBottom>Reihenfolge der Auszahlungen:</Typography>
+              <List>
+                {preview.order.map((m, idx) => (
+                  <ListItem key={m.uid}>
+                    <ListItemText primary={`${idx + 1}. ${m.firstName || m.lastName ? `${m.firstName || ''} ${m.lastName || ''}`.trim() : m.username}`} />
+                  </ListItem>
+                ))}
+              </List>
+              <Typography>Auszahlung pro Monat: {preview.payoutPerInterval} €</Typography>
+              <Typography>Runden: {preview.rounds}</Typography>
+              <Typography>Voraussichtliches Ende: {new Date(preview.expectedEndDate).toLocaleDateString()}</Typography>
+            </>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)}>Abbrechen</Button>
+          <Button onClick={handleStart} disabled={!preview}>Bestätigen</Button>
+        </DialogActions>
+      </Dialog>
+    </>
   );
 };

--- a/frontend/src/pages/votes/votes.tsx
+++ b/frontend/src/pages/votes/votes.tsx
@@ -107,7 +107,7 @@ export const Votes = () => {
       <Box display="flex" justifyContent="space-between" alignItems="center" mb={4}>
         <Typography variant="h4" fontWeight="bold">Abstimmungen</Typography>
         <Stack direction="row" spacing={2}>
-          {jamiah && user?.uid === jamiah.ownerId && !cycleStarted && (
+          {jamiah && user?.uid === jamiah.ownerId && !cycleStarted && (jamiah.currentMembers || 0) >= 2 && (
             <StartCycleButton
               jamiahId={jamiah.id as string}
               onStarted={() => setCycleStarted(true)}


### PR DESCRIPTION
## Summary
- allow jamiah owners to preview payout order, rounds, and end date before starting
- track per-member payment confirmations and receipt acknowledgments
- show jamiah start button only when at least two members and provide start dialog

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68988f9b74688333810aded35aa55439