### PR TITLE
Add Flyway migration for votes

### DIFF
--- a/backend/src/main/resources/db/migration/V16__create_votes_tables.sql
+++ b/backend/src/main/resources/db/migration/V16__create_votes_tables.sql
@@ -1,0 +1,22 @@
+CREATE TABLE votes (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255),
+    created_at DATETIME,
+    expires_at DATETIME,
+    closed BOOLEAN,
+    result VARCHAR(255)
+);
+
+CREATE TABLE vote_options (
+    vote_id BIGINT NOT NULL,
+    option_value VARCHAR(255),
+    CONSTRAINT fk_vote_options_vote FOREIGN KEY (vote_id) REFERENCES votes(id) ON DELETE CASCADE
+);
+
+CREATE TABLE vote_ballots (
+    vote_id BIGINT NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    choice VARCHAR(255),
+    PRIMARY KEY (vote_id, user_id),
+    CONSTRAINT fk_vote_ballots_vote FOREIGN KEY (vote_id) REFERENCES votes(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- create votes table and associated vote_options and vote_ballots join tables via Flyway migration

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689894a0cc3083339cb5fd9330840a8e