### PR TITLE
Enable CORS for vote endpoints

### DIFF
--- a/backend/src/main/java/com/example/backend/vote/VoteController.java
+++ b/backend/src/main/java/com/example/backend/vote/VoteController.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/votes")
+@CrossOrigin(origins = "*")
 public class VoteController {
     private final VoteService service;
 


### PR DESCRIPTION
## Summary
- allow cross-origin requests for vote APIs by adding `@CrossOrigin` annotation

## Testing
- `./mvnw -q test` *(failed: Non-resolvable parent POM – network unreachable)*
- `npm test` *(no tests, process awaited input)*

------
https://chatgpt.com/codex/tasks/task_e_689897b87a8c8333afbb71a04fb1ea15