### PR TITLE
Defer Jamiah cycle start until explicitly triggered

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahService.java
@@ -70,6 +70,7 @@ public class JamiahService {
     public JamiahDto create(JamiahDto dto, String uid) {
         validateParameters(dto);
         Jamiah entity = mapper.toEntity(dto);
+        entity.setStartDate(null); // ensure cycle not started on creation
         if (uid != null) {
             com.example.backend.UserProfile user = userRepository.findByUid(uid)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
@@ -86,6 +87,7 @@ public class JamiahService {
     public JamiahDto createJamiah(String ownerUid, JamiahDto dto) {
         validateParameters(dto);
         Jamiah j = mapper.toEntity(dto);
+        j.setStartDate(null); // ensure cycle not started on creation
         j.setOwnerId(ownerUid);
         if (ownerUid != null) {
             com.example.backend.UserProfile user = userRepository.findByUid(ownerUid)

--- a/backend/src/test/java/com/example/backend/jamiah/JamiahServiceTest.java
+++ b/backend/src/test/java/com/example/backend/jamiah/JamiahServiceTest.java
@@ -209,6 +209,27 @@ class JamiahServiceTest {
     }
 
     @Test
+    void newJamiahHasNoStartDate() {
+        UserProfile user = new UserProfile();
+        user.setUsername("owner2");
+        user.setUid("owner2");
+        userRepository.save(user);
+
+        JamiahDto dto = new JamiahDto();
+        dto.setName("NoStartDate");
+        dto.setIsPublic(true);
+        dto.setMaxGroupSize(3);
+        dto.setCycleCount(1);
+        dto.setRateAmount(new BigDecimal("5"));
+        dto.setRateInterval(RateInterval.MONTHLY);
+        dto.setStartDate(LocalDate.now());
+
+        service.createJamiah("owner2", dto);
+        Jamiah jamiah = repository.findAll().get(0);
+        assertNull(jamiah.getStartDate());
+    }
+
+    @Test
     void onlyOwnerCanModify() {
         UserProfile owner = new UserProfile();
         owner.setUsername("owner");


### PR DESCRIPTION
## Summary
- Ensure Jamiah creation does not set a start date so cycles begin only when started
- Add regression test verifying new Jamiahs have no start date

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6898ab365284833384fb4bf154fde166