### PR TITLE
feat: expand responsive layout

### DIFF
--- a/frontend/src/components/landing/banner.tsx
+++ b/frontend/src/components/landing/banner.tsx
@@ -10,19 +10,29 @@ export const Banner = () => {
                     backgroundImage:`url(${cover})`,
                     backgroundRepeat: "no-repeat",
                     backgroundSize: "cover",
-                    height: "70vh"
+                    height: {xs: "40vh", md: "70vh"},
+                    display: "flex",
+                    flexDirection: "column",
+                    justifyContent: "center",
+                    px: {xs: 2, md: 12}
                 }}>
                 <Typography
                     variant="h2"
                     color="white"
-                    style={{width: "40%", paddingTop: "200px", paddingLeft: "100px"}}>
+                    sx={{
+                        width: {xs: "100%", md: "40%"},
+                        fontSize: {xs: "2rem", md: "3rem"}
+                    }}>
                     <b>Wir machen Risiken handelbar!</b>
                 </Typography>
 
                 <Typography
                     variant="h4"
                     color="white"
-                    style={{width: "40%", paddingLeft: "100px"}}>
+                    sx={{
+                        width: {xs: "100%", md: "40%"},
+                        mt: {xs: 2, md: 0}
+                    }}>
                     Wir sind die intelligente Plattform für Partner-basierte Risiko-Transformation!
                 </Typography>
             </Box>

--- a/frontend/src/components/layout/footer.tsx
+++ b/frontend/src/components/layout/footer.tsx
@@ -11,12 +11,17 @@ export const Footer = () => {
             <Grid
                 container
                 id="footer"
-                style={{backgroundColor: "#1F271B", padding: "40px 80px", marginTop: "auto", width: "100%"}}
+                sx={{
+                    backgroundColor: "#1F271B",
+                    p: {xs: "40px 20px", md: "40px 80px"},
+                    mt: "auto",
+                    width: "100%"
+                }}
             >
-                <Grid size={2}>
+                <Grid xs={12} sm={6} md={2} sx={{mb: {xs: 4, md: 0}}}>
                     <img src={Logo} style={{width: "80px", height: "70px"}} alt="logo"/>
                 </Grid>
-                <Grid size={2}>
+                <Grid xs={12} sm={6} md={2} sx={{mb: {xs: 4, md: 0}}}>
                     <Typography variant="h6" color="white">Product</Typography>
                     <br />
                     <Typography color="white" variant="body2">Pricing</Typography>
@@ -31,7 +36,7 @@ export const Footer = () => {
                     </div>
 
                 </Grid>
-                <Grid size={2}>
+                <Grid xs={12} sm={6} md={2} sx={{mb: {xs: 4, md: 0}}}>
                     <Typography variant="h6" color="white">Solutions</Typography>
                     <br />
                     <Typography color="white" variant="body2">Brainstorming</Typography>
@@ -42,7 +47,7 @@ export const Footer = () => {
                     <br />
                     <Typography color="white" variant="body2">Research</Typography>
                 </Grid>
-                <Grid size={2}>
+                <Grid xs={12} sm={6} md={2} sx={{mb: {xs: 4, md: 0}}}>
                     <Typography variant="h6" color="white">Resources</Typography>
                     <br />
                     <Typography color="white" variant="body2">Help Center</Typography>
@@ -53,7 +58,7 @@ export const Footer = () => {
                     <br />
                     <Typography color="white" variant="body2">FAQs</Typography>
                 </Grid>
-                <Grid size={2}>
+                <Grid xs={12} sm={6} md={2} sx={{mb: {xs: 4, md: 0}}}>
                     <Typography variant="h6" color="white">Support</Typography>
                     <br />
                     <Typography color="white" variant="body2">Contact Us</Typography>
@@ -64,7 +69,7 @@ export const Footer = () => {
                     <br />
                     <Typography color="white" variant="body2">Integrations</Typography>
                 </Grid>
-                <Grid size={2}>
+                <Grid xs={12} sm={6} md={2} sx={{mb: {xs: 4, md: 0}}}>
                     <Typography variant="h6" color="white">Company</Typography>
                     <br />
                     <Typography color="white" variant="body2">About</Typography>
@@ -75,21 +80,28 @@ export const Footer = () => {
                     <br />
                     <Typography color="white" variant="body2">Request Demo</Typography>
                 </Grid>
-                <Grid size={12} style={{marginTop: "50px"}}>
+                <Grid xs={12} sx={{mt: "50px"}}>
                     <Divider color="white"/>
                 </Grid>
-                <Grid size={6} style={{marginTop: "20px"}}>
+                <Grid xs={12} md={6} sx={{mt: "20px"}}>
                     <Typography color="white">© {new Date().getFullYear()} XRISK AG. All rights reserved</Typography>
                 </Grid>
-                <Grid size={6} display="flex" justifyContent="right" style={{marginTop: "20px"}}>
-                    <Typography color="white" variant="body2" style={{ marginLeft: "10px", marginRight: "10px" }}>Imprint</Typography>
-                    <Typography color="white" variant="body2" style={{ marginLeft: "10px", marginRight: "10px" }}>Terms</Typography>
-                    <Typography color="white" variant="body2" style={{ marginLeft: "10px", marginRight: "10px" }}>Privacy</Typography>
-                    <Typography color="white" variant="body2" style={{ marginLeft: "10px", marginRight: "10px" }}>Support</Typography>
-                    <Typography color="white" variant="body2" style={{ marginLeft: "10px", marginRight: "10px" }}>About</Typography>
-                    <Typography color="white" variant="body2" style={{ marginLeft: "10px", marginRight: "10px" }}>Contact</Typography>
-                    <LinkedInIcon style={{color: "white", marginLeft: "10px", marginRight: "10px"}}/>
-                    <XIcon style={{color: "white", marginLeft: "10px", marginRight: "10px"}}/>
+                <Grid
+                    xs={12}
+                    md={6}
+                    display="flex"
+                    justifyContent={{xs: "center", md: "flex-end"}}
+                    flexWrap="wrap"
+                    sx={{mt: "20px", gap: 2}}
+                >
+                    <Typography color="white" variant="body2">Imprint</Typography>
+                    <Typography color="white" variant="body2">Terms</Typography>
+                    <Typography color="white" variant="body2">Privacy</Typography>
+                    <Typography color="white" variant="body2">Support</Typography>
+                    <Typography color="white" variant="body2">About</Typography>
+                    <Typography color="white" variant="body2">Contact</Typography>
+                    <LinkedInIcon sx={{color: "white"}}/>
+                    <XIcon sx={{color: "white"}}/>
                 </Grid>
             </Grid>
 

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -55,7 +55,7 @@ export function Header() {
 
     return (
         <AppBar position="static" elevation={0} sx={{backgroundColor: "#1F271B"}}>
-            <Container maxWidth="xl">
+            <Container maxWidth="xl" sx={{px: {xs: 2, md: 6}}}>
                 <Toolbar disableGutters>
                     <Box
                         onClick={() => navigate('/')}

--- a/frontend/src/components/layout/layout.tsx
+++ b/frontend/src/components/layout/layout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {Footer} from "./footer";
 import {Header} from "./header";
+import Container from '@mui/material/Container';
 
 export interface LayoutProps {
     children: React.ReactNode;
@@ -10,9 +11,14 @@ export const Layout = (props: LayoutProps) => {
     return (
         <div className="layout">
             <Header/>
-            <main className="main-content">
+            <Container
+                component="main"
+                className="main-content"
+                maxWidth="lg"
+                sx={{px: {xs: 0, sm: 2}}}
+            >
                 {props.children}
-            </main>
+            </Container>
             <Footer />
         </div>
     )

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -4,6 +4,13 @@ html, body, #root {
   padding: 0;
 }
 
+img,
+video {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
 body {
   display: flex;
   flex-direction: column;
@@ -20,8 +27,23 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100%;
+  padding: 0 2rem;
 }
 
 .main-content {
   flex: 1;
+  padding: 2rem 0;
+}
+
+@media (max-width: 600px) {
+  body {
+    font-size: 0.9rem;
+  }
+  .layout {
+    padding: 0 1rem;
+  }
+
+  .main-content {
+    padding: 1rem 0;
+  }
 }


### PR DESCRIPTION
## Summary
- make images and videos scale fluidly with global CSS and smaller body font on phones
- add responsive horizontal padding to main container and header
- refactor footer and banner into responsive grids for mobile viewing

## Testing
- `CI=true npm test -- --passWithNoTests`
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898afefa6008333a8f2472eb8059d8e