### PR TITLE
Schedule next Jamiah round using cycle interval and show payment confirmation feedback

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
@@ -88,8 +88,10 @@ public class JamiahController {
     }
 
     @GetMapping("/{id}/cycles/{cycleId}/payments")
-    public java.util.List<JamiahPayment> payments(@PathVariable String id, @PathVariable Long cycleId) {
-        return service.getPayments(cycleId);
+    public java.util.List<JamiahPayment> payments(@PathVariable String id,
+                                                  @PathVariable Long cycleId,
+                                                  @RequestParam String uid) {
+        return service.getPayments(cycleId, uid);
     }
 
     @PostMapping("/{id}/cycles/{cycleId}/payments/{paymentId}/confirm-receipt")

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahPaymentRepository.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahPaymentRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface JamiahPaymentRepository extends JpaRepository<JamiahPayment, Long> {
     long countByCycleId(Long cycleId);
     java.util.List<JamiahPayment> findByCycleId(Long cycleId);
+    java.util.Optional<JamiahPayment> findByCycleIdAndUserUid(Long cycleId, String uid);
 }

--- a/backend/src/test/java/com/example/backend/jamiah/JamiahServiceCycleTest.java
+++ b/backend/src/test/java/com/example/backend/jamiah/JamiahServiceCycleTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -85,6 +86,95 @@ public class JamiahServiceCycleTest {
         assertFalse(cycleRepository.findById(cycle.getId()).get().getCompleted());
         service.confirmPaymentReceipt(cycle.getId(), p1.getId(), "u1");
         service.confirmPaymentReceipt(cycle.getId(), p2.getId(), "u1");
-        assertTrue(cycleRepository.findById(cycle.getId()).get().getCompleted());
+        JamiahCycle completed = cycleRepository.findById(cycle.getId()).orElseThrow();
+        assertTrue(completed.getCompleted());
+        JamiahCycle next = cycleRepository.findByJamiahId(jamiah.getId()).stream()
+                .filter(c -> c.getCycleNumber() == 2)
+                .findFirst()
+                .orElse(null);
+        assertNotNull(next);
+        assertEquals(completed.getStartDate().plusMonths(1), next.getStartDate());
+    }
+
+    @Test
+    void previewStartCalculatesEndDate() {
+        UserProfile owner = new UserProfile();
+        owner.setUsername("owner");
+        owner.setUid("u1");
+        userRepository.save(owner);
+        UserProfile member = new UserProfile();
+        member.setUsername("m");
+        member.setUid("u2");
+        userRepository.save(member);
+
+        JamiahDto created = createJamiah("u1");
+        Jamiah jamiah = jamiahRepository.findAll().get(0);
+        jamiah.getMembers().add(member);
+        member.getJamiahs().add(jamiah);
+        jamiahRepository.save(jamiah);
+
+        com.example.backend.jamiah.dto.StartPreviewDto preview = service.previewStart(created.getId().toString(), "u1");
+        assertEquals(LocalDate.now().plusMonths(1), preview.getExpectedEndDate());
+    }
+
+    @Test
+    void recordPaymentIsIdempotent() {
+        UserProfile owner = new UserProfile();
+        owner.setUsername("owner");
+        owner.setUid("u1");
+        userRepository.save(owner);
+        UserProfile member = new UserProfile();
+        member.setUsername("m");
+        member.setUid("u2");
+        userRepository.save(member);
+
+        JamiahDto created = createJamiah("u1");
+        Jamiah jamiah = jamiahRepository.findAll().get(0);
+        jamiah.getMembers().add(member);
+        member.getJamiahs().add(jamiah);
+        jamiahRepository.save(jamiah);
+
+        JamiahCycle cycle = service.startCycle(created.getId().toString(), "u1", java.util.Arrays.asList("u1", "u2"));
+        JamiahPayment first = service.recordPayment(cycle.getId(), "u1", new BigDecimal("5"));
+        JamiahPayment second = service.recordPayment(cycle.getId(), "u1", new BigDecimal("5"));
+        assertEquals(first.getId(), second.getId());
+        assertEquals(1, paymentRepository.countByCycleId(cycle.getId()));
+    }
+
+    @Test
+    void getPaymentsReturnsAccordingToRole() {
+        UserProfile owner = new UserProfile();
+        owner.setUsername("owner");
+        owner.setUid("u1");
+        userRepository.save(owner);
+
+        UserProfile recipient = new UserProfile();
+        recipient.setUsername("rec");
+        recipient.setUid("u2");
+        userRepository.save(recipient);
+
+        UserProfile member = new UserProfile();
+        member.setUsername("m");
+        member.setUid("u3");
+        userRepository.save(member);
+
+        JamiahDto created = createJamiah("u1");
+        Jamiah jamiah = jamiahRepository.findAll().get(0);
+        jamiah.getMembers().add(recipient);
+        recipient.getJamiahs().add(jamiah);
+        jamiah.getMembers().add(member);
+        member.getJamiahs().add(jamiah);
+        jamiahRepository.save(jamiah);
+
+        JamiahCycle cycle = service.startCycle(created.getId().toString(), "u1",
+                java.util.Arrays.asList("u2", "u3", "u1"));
+
+        service.recordPayment(cycle.getId(), "u1", new BigDecimal("5"));
+        service.recordPayment(cycle.getId(), "u2", new BigDecimal("5"));
+        service.recordPayment(cycle.getId(), "u3", new BigDecimal("5"));
+
+        assertEquals(3, service.getPayments(cycle.getId(), "u1").size());
+        assertEquals(3, service.getPayments(cycle.getId(), "u2").size());
+        assertEquals(1, service.getPayments(cycle.getId(), "u3").size());
     }
 }


### PR DESCRIPTION
## Summary
- Respect configured start date when starting a Jamiah cycle and in start preview
- Schedule subsequent rounds using the Jamiah's rate interval
- Extend cycle tests for next-round timing and expected end date calculation
- Prevent duplicate payment confirmations and cover with a unit test
- Show snackbar feedback in the payments page when confirming payments or receipts
- Restrict payment list visibility to the admin or current recipient and pass the user ID from the frontend
- Cover payment visibility rules with a new integration test
- Display per-round payment and receipt counts along with overall status in the payments page

## Testing
- `cd backend && ./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*
- `cd frontend && CI=true npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6898b5aa3df48333af7c1bfb518b9716