### PR TITLE
Gracefully handle API errors in payments and dashboard

### DIFF
--- a/frontend/src/pages/dashboard/dashboard.tsx
+++ b/frontend/src/pages/dashboard/dashboard.tsx
@@ -34,25 +34,29 @@ export const Dashboard = () => {
   useEffect(() => {
     if (!groupId) return;
     fetch(`${API_BASE_URL}/api/jamiahs/${groupId}`)
-      .then(res => res.json())
+      .then(res => res.ok ? res.json() : Promise.reject())
       .then(data => setJamiah(data))
       .catch(() => setJamiah(null));
 
     fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/members`)
-      .then(res => res.json())
-      .then(data => setMembers(data))
+      .then(res => res.ok ? res.json() : Promise.reject())
+      .then(data => setMembers(Array.isArray(data) ? data : []))
       .catch(() => setMembers([]));
 
     fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/cycles`)
-      .then(res => res.json())
+      .then(res => res.ok ? res.json() : Promise.reject())
       .then(data => {
-        const active = data[data.length - 1];
-        setCycle(active);
-        if (active) {
-          fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/cycles/${active.id}/payments`)
-            .then(res => res.json())
-            .then(p => setPayments(p))
-            .catch(() => setPayments([]));
+        if (Array.isArray(data)) {
+          const active = data[data.length - 1];
+          setCycle(active);
+          if (active) {
+            fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/cycles/${active.id}/payments`)
+              .then(res => res.ok ? res.json() : Promise.reject())
+              .then(p => setPayments(Array.isArray(p) ? p : []))
+              .catch(() => setPayments([]));
+          }
+        } else {
+          setCycle(null);
         }
       })
       .catch(() => setCycle(null));

--- a/frontend/src/pages/payments/payments.tsx
+++ b/frontend/src/pages/payments/payments.tsx
@@ -55,24 +55,31 @@ export const Payments = () => {
       });
 
     fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/members`)
-      .then(r => r.json())
-      .then(data => setMembers(data));
+      .then(r => r.ok ? r.json() : Promise.reject())
+      .then(data => setMembers(Array.isArray(data) ? data : []))
+      .catch(() => setMembers([]));
 
     fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/cycles`)
-      .then(r => r.json())
+      .then(r => r.ok ? r.json() : Promise.reject())
       .then(data => {
-        setCycles(data);
-        if (data.length > 0) {
-          setSelectedCycle(data[data.length - 1].id);
+        if (Array.isArray(data)) {
+          setCycles(data);
+          if (data.length > 0) {
+            setSelectedCycle(data[data.length - 1].id);
+          }
+        } else {
+          setCycles([]);
         }
-      });
+      })
+      .catch(() => setCycles([]));
   }, [groupId, currentUid]);
 
   const fetchPayments = (cycleId: number) => {
     const uid = currentUid || '';
     fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/cycles/${cycleId}/payments?uid=${encodeURIComponent(uid)}`)
-      .then(r => r.json())
-      .then(data => setPayments(data));
+      .then(r => r.ok ? r.json() : Promise.reject())
+      .then(data => setPayments(Array.isArray(data) ? data : []))
+      .catch(() => setPayments([]));
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Validate cycle, member, and payment API responses before using them
- Prevent crashes when the backend returns errors

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689acb6f594883338a69235c887c510f