### PR TITLE
Fix payment public ID check and admin view

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/JamiahRepository.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahRepository.java
@@ -9,6 +9,13 @@ import java.util.Optional;
 public interface JamiahRepository extends JpaRepository<Jamiah, Long> {
     Optional<Jamiah> findByInvitationCode(String invitationCode);
 
+    default Optional<Jamiah> findByPublicId(String publicId) {
+        java.util.UUID uuid = java.util.UUID.fromString(publicId);
+        return findAll().stream()
+                .filter(j -> java.util.UUID.nameUUIDFromBytes(j.getId().toString().getBytes()).equals(uuid))
+                .findFirst();
+    }
+
     @Query("select j from Jamiah j left join fetch j.members where j.invitationCode = :code")
     Optional<Jamiah> findWithMembersByInvitationCode(@Param("code") String invitationCode);
 


### PR DESCRIPTION
## Summary
- Ensure public ID verification uses repository lookup
- Block recipients from confirming payments in their own rounds and require confirmed payments before receipt confirmation
- Auto-select active cycle and hide payment actions from the round's recipient

## Testing
- `./backend/mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689b46ce0ed08333b7c06100df7a3138