### PR TITLE
Add cycle summary endpoint and refine payment flows

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahController.java
@@ -97,6 +97,12 @@ public class JamiahController {
         return paymentService.getPayments(id, cycleId, uid);
     }
 
+    @GetMapping("/{id}/cycles/summary")
+    public java.util.List<com.example.backend.jamiah.dto.CycleSummaryDto> cycleSummary(@PathVariable String id,
+                                                                                       @RequestParam String uid) {
+        return paymentService.getCycleSummaries(id, uid);
+    }
+
     @PostMapping("/{id}/cycles/{cycleId}/payments/{paymentId}/confirm-receipt")
     public PaymentDto confirmPaymentReceipt(@PathVariable String id,
                                             @PathVariable Long cycleId,

--- a/backend/src/main/java/com/example/backend/jamiah/dto/CycleSummaryDto.java
+++ b/backend/src/main/java/com/example/backend/jamiah/dto/CycleSummaryDto.java
@@ -1,0 +1,38 @@
+package com.example.backend.jamiah.dto;
+
+import java.time.LocalDate;
+
+public class CycleSummaryDto {
+    private Long id;
+    private Integer cycleNumber;
+    private LocalDate startDate;
+    private boolean completed;
+    private String recipientUid;
+    private int totalPayers;
+    private int paidCount;
+    private int receiptCount;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Integer getCycleNumber() { return cycleNumber; }
+    public void setCycleNumber(Integer cycleNumber) { this.cycleNumber = cycleNumber; }
+
+    public LocalDate getStartDate() { return startDate; }
+    public void setStartDate(LocalDate startDate) { this.startDate = startDate; }
+
+    public boolean isCompleted() { return completed; }
+    public void setCompleted(boolean completed) { this.completed = completed; }
+
+    public String getRecipientUid() { return recipientUid; }
+    public void setRecipientUid(String recipientUid) { this.recipientUid = recipientUid; }
+
+    public int getTotalPayers() { return totalPayers; }
+    public void setTotalPayers(int totalPayers) { this.totalPayers = totalPayers; }
+
+    public int getPaidCount() { return paidCount; }
+    public void setPaidCount(int paidCount) { this.paidCount = paidCount; }
+
+    public int getReceiptCount() { return receiptCount; }
+    public void setReceiptCount(int receiptCount) { this.receiptCount = receiptCount; }
+}

--- a/frontend/src/pages/payments/payments.tsx
+++ b/frontend/src/pages/payments/payments.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import {
   Box, Typography, Paper, List, ListItem, ListItemText, Button,
-  TextField, MenuItem, Snackbar, Alert
+  TextField, MenuItem, Snackbar, Alert, Tooltip, Skeleton, Chip, LinearProgress
 } from '@mui/material';
 import EuroIcon from '@mui/icons-material/Euro';
 import { API_BASE_URL } from '../../constants/api';
@@ -30,12 +30,26 @@ interface Cycle {
   recipient?: { uid: string };
 }
 
+interface CycleSummary {
+  id: number;
+  cycleNumber: number;
+  startDate: string;
+  completed: boolean;
+  recipientUid?: string;
+  totalPayers: number;
+  paidCount: number;
+  receiptCount: number;
+}
+
 export const Payments = () => {
   const [isOwner, setIsOwner] = useState(false);
   const [members, setMembers] = useState<Member[]>([]);
   const [payments, setPayments] = useState<Payment[]>([]);
   const [cycles, setCycles] = useState<Cycle[]>([]);
   const [selectedCycle, setSelectedCycle] = useState<number | null>(null);
+  const [summary, setSummary] = useState<CycleSummary[]>([]);
+  const [loadingCycles, setLoadingCycles] = useState(false);
+  const [loadingPayments, setLoadingPayments] = useState(false);
   const [amount, setAmount] = useState<number>(50);
   const [snackbar, setSnackbar] = useState<{message: string; severity: 'success' | 'error'} | null>(null);
 
@@ -44,21 +58,18 @@ export const Payments = () => {
   const groupId = window.location.pathname.split('/')[2];
 
   useEffect(() => {
+    let owner = false;
+
     fetch(`${API_BASE_URL}/api/jamiahs/${groupId}`)
       .then(r => r.json())
       .then(data => {
         setAmount(data.rateAmount || 50);
-        const owner = data.ownerId === currentUid;
+        owner = data.ownerId === currentUid;
         setIsOwner(owner);
-      });
-
-    fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/members`)
-      .then(r => r.ok ? r.json() : Promise.reject())
-      .then(data => setMembers(Array.isArray(data) ? data : []))
-      .catch(() => setMembers([]));
-
-    fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/cycles`)
-      .then(r => r.ok ? r.json() : Promise.reject())
+        setLoadingCycles(true);
+        return fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/cycles`);
+      })
+      .then(r => (r ? (r.ok ? r.json() : Promise.reject()) : []))
       .then(data => {
         if (Array.isArray(data)) {
           setCycles(data);
@@ -68,25 +79,50 @@ export const Payments = () => {
             const upcoming = data
               .filter((c: Cycle) => !c.completed && parse(c.startDate) <= today)
               .sort((a: Cycle, b: Cycle) => parse(a.startDate).getTime() - parse(b.startDate).getTime());
-            const initial = upcoming[0]?.id ?? data[data.length - 1].id;
-            setSelectedCycle(initial);
+            const initial = upcoming[0]?.id ?? data[data.length - 1]?.id ?? null;
+            if (!owner) {
+              setSelectedCycle(initial);
+            } else {
+              setSelectedCycle(prev => prev ?? initial);
+            }
           }
         } else {
           setCycles([]);
         }
       })
-      .catch(() => setCycles([]));
+      .catch(() => setCycles([]))
+      .finally(() => setLoadingCycles(false));
+
+    fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/members`)
+      .then(r => r.ok ? r.json() : Promise.reject())
+      .then(data => setMembers(Array.isArray(data) ? data : []))
+      .catch(() => setMembers([]));
   }, [groupId, currentUid]);
+
+  useEffect(() => {
+    if (isOwner) fetchCycleSummary();
+  }, [isOwner, groupId, currentUid]);
 
   const fetchPayments = (cycleId: number) => {
     const uid = currentUid || '';
+    setLoadingPayments(true);
     fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/cycles/${cycleId}/payments?uid=${encodeURIComponent(uid)}`)
       .then(r => r.ok ? r.json() : Promise.reject())
       .then(data => setPayments(Array.isArray(data) ? data : []))
       .catch(() => {
         setPayments([]);
         setSnackbar({ message: 'Fehler beim Laden', severity: 'error' });
-      });
+      })
+      .finally(() => setLoadingPayments(false));
+  };
+
+  const fetchCycleSummary = () => {
+    if (!isOwner) return;
+    const uid = currentUid || '';
+    fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/cycles/summary?uid=${encodeURIComponent(uid)}`)
+      .then(r => r.ok ? r.json() : Promise.reject())
+      .then(data => setSummary(Array.isArray(data) ? data : []))
+      .catch(() => setSummary([]));
   };
 
   useEffect(() => {
@@ -101,7 +137,7 @@ export const Payments = () => {
   };
 
   const currentCycle = cycles.find(c => c.id === selectedCycle) || null;
-  const isRecipient = currentCycle?.recipient?.uid === currentUid;
+  const isRecipient = Boolean(currentCycle?.recipient?.uid && currentUid && currentCycle.recipient.uid === currentUid);
 
   const recipientUid = currentCycle?.recipient?.uid;
   const totalPayers = members.filter(m => m.uid !== recipientUid).length;
@@ -123,6 +159,7 @@ export const Payments = () => {
       .then(() => {
         setSnackbar({ message: 'Zahlung bestätigt', severity: 'success' });
         fetchPayments(selectedCycle);
+        fetchCycleSummary(); // Admin-Übersicht sofort aktualisieren
       })
       .catch(() => setSnackbar({ message: 'Fehler bei Zahlungsbestätigung', severity: 'error' }));
   };
@@ -135,36 +172,67 @@ export const Payments = () => {
       .then(() => {
         setSnackbar({ message: 'Empfang bestätigt', severity: 'success' });
         fetchPayments(selectedCycle);
+        fetch(`${API_BASE_URL}/api/jamiahs/${groupId}/cycles`)
+          .then(r => r.ok ? r.json() : Promise.reject())
+          .then(data => {
+            if (Array.isArray(data)) {
+              setCycles(data);
+              const today = new Date();
+              const parse = (s: string) => new Date(s);
+              const upcoming = data
+                .filter((c: Cycle) => !c.completed && parse(c.startDate) <= today)
+                .sort((a: Cycle, b: Cycle) => parse(a.startDate).getTime() - parse(b.startDate).getTime());
+              const initial = upcoming[0]?.id ?? data[data.length - 1]?.id ?? null;
+              if (!isOwner) {
+                setSelectedCycle(initial);
+              }
+            }
+          })
+          .finally(() => fetchCycleSummary());
       })
       .catch(() => setSnackbar({ message: 'Fehler beim Empfangsbestätigen', severity: 'error' }));
   };
+
+  const getSortKey = (m: Member) => {
+    if (m.uid === recipientUid) return 0;
+    const payment = payments.find(p => p.user.uid === m.uid);
+    if (!payment || !payment.confirmed) return 1; // Zahlung offen
+    if (payment.confirmed && !payment.recipientConfirmed) return 2; // bezahlt, Eingang offen
+    return 3; // Empfang bestätigt
+  };
+  const sortedMembers = [...members].sort((a, b) => getSortKey(a) - getSortKey(b));
 
   const renderMemberRow = (m: Member) => {
     const payment = payments.find(p => p.user.uid === m.uid);
     const name = m.firstName || m.lastName ? `${m.firstName || ''} ${m.lastName || ''}`.trim() : m.username;
     const isRoundRecipient = m.uid === currentCycle?.recipient?.uid;
-    const disableMemberConfirm = selectedCycle === null || isRecipient;
-    if (m.uid === currentUid && disableMemberConfirm) {
-      console.log('Mitglieds-Button deaktiviert', {
-        selectedCycleNull: selectedCycle === null,
-        isRecipient,
-      });
-    }
+    const disableMemberConfirm = selectedCycle === null || isRecipient || !!payment?.confirmed;
     let action;
     if (m.uid === currentUid && isRecipient) {
       action = <Typography variant="body2">Empfänger zahlt nicht</Typography>;
     } else if (payment) {
       if (m.uid === currentUid) {
         if (!payment.confirmed) {
+          const tip = selectedCycle === null
+            ? 'Keine aktive Runde'
+            : isRecipient
+              ? 'Du bist Empfänger'
+              : payment.confirmed
+                ? 'Schon bestätigt'
+                : '';
           action = (
-            <Button
-              size="small"
-              variant="outlined"
-              onClick={() => handleConfirm(m.uid)}
-              disabled={disableMemberConfirm}
-            >
-              Zahlung bestätigen
-            </Button>
+            <Tooltip title={tip} disableHoverListener={!tip} disableFocusListener={!tip} disableTouchListener={!tip}>
+              <span>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  onClick={() => handleConfirm(m.uid)}
+                  disabled={disableMemberConfirm}
+                >
+                  Zahlung bestätigen
+                </Button>
+              </span>
+            </Tooltip>
           );
         } else {
           action = (
@@ -189,15 +257,26 @@ export const Payments = () => {
         action = <Typography variant="body2">Zahlung offen</Typography>;
       }
     } else if (m.uid === currentUid) {
+      const tip = selectedCycle === null
+        ? 'Keine aktive Runde'
+        : isRecipient
+          ? 'Du bist Empfänger'
+          : payment?.confirmed
+            ? 'Schon bestätigt'
+            : '';
       action = (
-        <Button
-          size="small"
-          variant="outlined"
-          onClick={() => handleConfirm(m.uid)}
-          disabled={disableMemberConfirm}
-        >
-          Zahlung bestätigen
-        </Button>
+        <Tooltip title={tip} disableHoverListener={!tip} disableFocusListener={!tip} disableTouchListener={!tip}>
+          <span>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => handleConfirm(m.uid)}
+              disabled={disableMemberConfirm}
+            >
+              Zahlung bestätigen
+            </Button>
+          </span>
+        </Tooltip>
       );
     } else {
       action = <Typography variant="body2">Nicht bestätigt</Typography>;
@@ -211,13 +290,6 @@ export const Payments = () => {
 
   const alreadyConfirmed = payments.some(p => p.user.uid === currentUid && p.confirmed);
   const disableTopConfirm = selectedCycle == null || isRecipient || alreadyConfirmed;
-  if (disableTopConfirm) {
-    console.log('Haupt-Button deaktiviert', {
-      selectedCycleNull: selectedCycle == null,
-      isRecipient,
-      alreadyConfirmed,
-    });
-  }
 
   return (
       <>
@@ -225,34 +297,96 @@ export const Payments = () => {
         <Box display="flex" justifyContent="space-between" alignItems="center" mb={4}>
           <Typography variant="h4" fontWeight="bold">Zahlungsübersicht</Typography>
           <Box display="flex" alignItems="center" gap={2}>
-            {cycles.length > 0 && (
-              <TextField
-                select
-                label="Zyklus"
-                value={selectedCycle ?? ''}
-                onChange={e => setSelectedCycle(Number(e.target.value))}
-                size="small"
-              >
-                {cycles.map(c => (
-                  <MenuItem key={c.id} value={c.id}>Zyklus {c.cycleNumber}</MenuItem>
-                ))}
-              </TextField>
+            {isOwner && (
+              loadingCycles ? (
+                <Skeleton variant="rectangular" width={120} height={40} />
+              ) : (
+                cycles.length > 0 && (
+                  <TextField
+                    select
+                    label="Runde"
+                    value={selectedCycle ?? ''}
+                    onChange={e => setSelectedCycle(Number(e.target.value))}
+                    size="small"
+                  >
+                    {cycles.map(c => (
+                      <MenuItem key={c.id} value={c.id}>Runde {c.cycleNumber}</MenuItem>
+                    ))}
+                  </TextField>
+                )
+              )
             )}
           </Box>
         </Box>
 
+        {isOwner && (
+          summary.length > 0 ? (
+            <Paper sx={{ p: 2, mb: 3 }}>
+              <Typography variant="h6" mb={2}>Runden-Übersicht</Typography>
+              {summary.map(s => {
+                const r = members.find(m => m.uid === s.recipientUid);
+                const name = r ? (r.firstName || r.lastName ? `${r.firstName || ''} ${r.lastName || ''}`.trim() : r.username) : s.recipientUid;
+                const status = s.completed
+                  ? 'abgeschlossen'
+                  : s.receiptCount === s.totalPayers
+                    ? 'vollständig bestätigt'
+                    : s.paidCount === s.totalPayers
+                      ? 'vollständig bezahlt'
+                      : 'offen';
+                const paidPct = s.totalPayers ? (s.paidCount / s.totalPayers) * 100 : 0;
+                const receiptPct = s.totalPayers ? (s.receiptCount / s.totalPayers) * 100 : 0;
+                return (
+                  <Box key={s.id} mb={2} sx={{ cursor: 'pointer' }} onClick={() => setSelectedCycle(s.id)}>
+                    <Typography variant="body2">Runde {s.cycleNumber} – Empfänger: {name}</Typography>
+                    <Box display="flex" alignItems="center" gap={1} mt={1}>
+                      <LinearProgress variant="determinate" value={paidPct} sx={{ flex: 1 }} />
+                      <LinearProgress variant="determinate" value={receiptPct} color="secondary" sx={{ flex: 1 }} />
+                      <Chip label={status} size="small" />
+                    </Box>
+                    <Typography variant="caption">Bezahlt {s.paidCount}/{s.totalPayers} – Empfang bestätigt {s.receiptCount}/{s.totalPayers}</Typography>
+                  </Box>
+                );
+              })}
+            </Paper>
+          ) : (
+            <Alert severity="info" sx={{ mb: 3 }}>
+              Noch keine Runden – Jamiah starten
+            </Alert>
+          )
+        )}
+
+        {cycles.length === 0 && (
+          <Alert severity="info" sx={{ mb: 3 }}>
+            Keine aktive Runde – bitte vom Admin starten lassen.
+          </Alert>
+        )}
         <Box mb={3}>
           <Button variant="contained" startIcon={<EuroIcon />} onClick={handlePay}>
             Beitrag bezahlen
           </Button>
-          <Button
-            sx={{ ml: 2 }}
-            variant="outlined"
-            onClick={() => handleConfirm(currentUid || '')}
-            disabled={disableTopConfirm}
-          >
-            Zahlung bestätigen
-          </Button>
+          {(() => {
+            const tip = selectedCycle == null
+              ? 'Keine aktive Runde'
+              : isRecipient
+                ? 'Du bist Empfänger'
+                : alreadyConfirmed
+                  ? 'Schon bestätigt'
+                  : '';
+            return (
+              <Tooltip title={tip} disableHoverListener={!tip} disableFocusListener={!tip} disableTouchListener={!tip}>
+                <span>
+                  <Button
+                    sx={{ ml: 2 }}
+                    variant="outlined"
+                    onClick={() => handleConfirm(currentUid || '')}
+                    disabled={disableTopConfirm}
+                  >
+                    Zahlung bestätigen
+                  </Button>
+                </span>
+              </Tooltip>
+            );
+          })()}
         </Box>
 
         {/* Eigene Kurzansicht immer anzeigen */}
@@ -265,9 +399,9 @@ export const Payments = () => {
           })()}
         </Typography>
 
-        {/* Zusatz-Card für Admin oder Empfänger */}
-        {(isOwner || isRecipient) && (
-          <Paper sx={{ p: 2 }}>
+        {/* Details zur aktuellen Runde */}
+        {currentCycle && (
+        <Paper sx={{ p: 2 }}>
             <Box mb={2}>
               <Typography variant="body2">Empfänger: {
                 (() => {
@@ -281,7 +415,11 @@ export const Payments = () => {
               <Typography variant="body2">Rundenstatus: {roundStatus}</Typography>
             </Box>
             <List>
-              {members.map(renderMemberRow)}
+              {loadingPayments ? (
+                <ListItem><Skeleton width="100%" /></ListItem>
+              ) : (
+                sortedMembers.map(renderMemberRow)
+              )}
             </List>
           </Paper>
         )}


### PR DESCRIPTION
## Summary
- Introduce cycle summary endpoint for admins and expose via controller
- Expand payment service with role checks, receipt handling, and summary counts
- Hide cycle switch for non-owners, auto-select active round, and add admin round overview with progress, tooltips, and sorting
- Refresh round summary after payments and avoid duplicate loading

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:backend: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b609e17b88333bd4a348ce54e1d5a