### PR TITLE
Fix payments summary conditional to restore build

### DIFF
--- a/frontend/src/pages/payments/payments.tsx
+++ b/frontend/src/pages/payments/payments.tsx
@@ -326,7 +326,7 @@ export const Payments = () => {
         </Box>
 
         {isOwner && (
-          summary.length > 0 ? (
+          summary.length > 0 && (
             <Paper sx={{ p: 2, mb: 3 }}>
               <Typography variant="h6" mb={2}>Runden-Übersicht</Typography>
               {summary.map(s => {


### PR DESCRIPTION
## Summary
- replace incomplete ternary with logical AND when rendering payments summary

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bc0106c2c8333ba56f679bbd026c3