### PR TITLE
Fix migration for MySQL compatibility

### DIFF
--- a/backend/src/main/resources/db/migration/V17__add_public_id_and_refactor_payments.sql
+++ b/backend/src/main/resources/db/migration/V17__add_public_id_and_refactor_payments.sql
@@ -1,14 +1,11 @@
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
+ALTER TABLE jamiah
+    ADD COLUMN public_id CHAR(36);
+
+-- generate identifiers for existing rows using MySQL's UUID function
+UPDATE jamiah SET public_id = UUID() WHERE public_id IS NULL;
 
 ALTER TABLE jamiah
-    ADD COLUMN public_id UUID;
-
--- generate identifiers for existing rows using PostgreSQL's pgcrypto extension
--- (gen_random_uuid). For other databases adjust accordingly.
-UPDATE jamiah SET public_id = gen_random_uuid() WHERE public_id IS NULL;
-
-ALTER TABLE jamiah
-    ALTER COLUMN public_id SET NOT NULL;
+    MODIFY public_id CHAR(36) NOT NULL;
 ALTER TABLE jamiah
     ADD CONSTRAINT uk_jamiah_public_id UNIQUE (public_id);
 
@@ -21,12 +18,11 @@ SET jamiah_id = (SELECT jc.jamiah_id FROM jamiah_cycles jc WHERE jc.id = jp.cycl
     payer_uid = (SELECT up.uid FROM user_profiles up WHERE up.id = jp.user_profile_id);
 
 ALTER TABLE jamiah_payments
-    ALTER COLUMN jamiah_id SET NOT NULL;
+    MODIFY jamiah_id BIGINT NOT NULL;
 ALTER TABLE jamiah_payments
-    ALTER COLUMN payer_uid SET NOT NULL;
+    MODIFY payer_uid VARCHAR(255) NOT NULL;
 
-ALTER TABLE jamiah_payments DROP CONSTRAINT IF EXISTS fk_payment_user;
-ALTER TABLE jamiah_payments DROP CONSTRAINT IF EXISTS jamiah_payments_user_profile_id_fkey;
+ALTER TABLE jamiah_payments DROP FOREIGN KEY fk_payment_user;
 ALTER TABLE jamiah_payments DROP COLUMN user_profile_id;
 ALTER TABLE jamiah_payments
     ADD CONSTRAINT fk_payment_jamiah FOREIGN KEY (jamiah_id) REFERENCES jamiah(id);


### PR DESCRIPTION
## Summary
- Replace Postgres pgcrypto usage with MySQL UUID() in migration
- Adjust jamiah_payments refactor statements for MySQL syntax

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for com.example:backend:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_689bc3f0e9e0833385f4256bffa76cfe