### PR TITLE
fix: store UUID as char

### DIFF
--- a/backend/src/main/java/com/example/backend/jamiah/Jamiah.java
+++ b/backend/src/main/java/com/example/backend/jamiah/Jamiah.java
@@ -21,7 +21,7 @@ public class Jamiah {
     /**
      * Public identifier exposed via the API.
      */
-    @Column(name = "public_id", nullable = false, unique = true, updatable = false, columnDefinition = "UUID")
+    @Column(name = "public_id", nullable = false, unique = true, updatable = false, length = 36)
     private UUID publicId;
 
     /**

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -18,4 +18,5 @@ spring.flyway.baseline-version=7
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.type.preferred_uuid_jdbc_type=CHAR
 


### PR DESCRIPTION
## Summary
- store `public_id` as 36-character string instead of binary UUID
- configure Hibernate to use CHAR for UUID JDBC type

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.0 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c4f1c00ec833394b3fe048764dab9