### PR TITLE
feat(profile): add paypal payout email

### DIFF
--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -10,6 +10,7 @@
     "birthDate": "Geburtsdatum",
     "address": "Adresse",
     "phone": "Telefonnummer",
+    "paypalEmail": "PayPal E-Mail",
     "language": "Sprache",
     "nationality": "Nationalit\u00e4t",
     "gender": "Geschlecht",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -10,6 +10,7 @@
     "birthDate": "Birth Date",
     "address": "Address",
     "phone": "Phone Number",
+    "paypalEmail": "PayPal Email",
     "language": "Language",
     "nationality": "Nationality",
     "gender": "Gender",

--- a/frontend/src/pages/profile/profile.tsx
+++ b/frontend/src/pages/profile/profile.tsx
@@ -20,7 +20,7 @@ export const Profile = () => {
   const methods = useForm<ProfileFormValues>({
     resolver: yupResolver(profileSchema) as Resolver<ProfileFormValues>,
     mode: 'onChange',
-    defaultValues: { avatar: null } as Partial<ProfileFormValues>
+    defaultValues: { avatar: null, paypalEmail: '' } as Partial<ProfileFormValues>
   });
 
   const { handleSubmit, reset, formState, watch } = methods;
@@ -39,6 +39,7 @@ export const Profile = () => {
             birthDate: data.birthDate || '',
             address: data.address || '',
             phone: data.phone || '',
+            paypalEmail: data.paypalEmail || '',
             language: data.language || '',
             nationality: data.nationality || '',
             gender: data.gender || '',
@@ -130,6 +131,9 @@ export const Profile = () => {
                   </Grid>
                   <Grid item xs={12} md={6}>
                     <FormField name="phone" label={t('profile.phone')} control={methods.control} />
+                  </Grid>
+                  <Grid item xs={12} md={6}>
+                    <FormField type="email" name="paypalEmail" label={t('profile.paypalEmail')} control={methods.control} />
                   </Grid>
                   <Grid item xs={12} md={6}>
                     <FormField

--- a/frontend/src/pages/profile/profileSchema.ts
+++ b/frontend/src/pages/profile/profileSchema.ts
@@ -16,6 +16,7 @@ export const profileSchema = yup.object({
   username: yup.string().min(3).test('unique', 'Benutzername bereits vergeben', checkUsernameUnique).required(),
   birthDate: yup.date().test('age', 'Du musst mindestens 18 Jahre alt sein', value => dayjs().diff(value, 'year') >= 18).required(),
   phone: yup.string().matches(/^\+?[0-9]{7,15}$/, 'Ung\u00fcltige Telefonnummer').optional(),
+  paypalEmail: yup.string().email().optional(),
   address: yup.string().min(2).required(),
   language: yup.string().required(),
   nationality: yup.string().required(),


### PR DESCRIPTION
## Summary
- allow users to store a PayPal email in their profile
- validate paypal email in profile schema and add translations

## Testing
- `./mvnw -q test` *(failed: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent: Network is unreachable)*
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689c5d3b2db48333a8549e4541ad3b6a