### PR TITLE
Fix Hibernate proxy serialization and ensure recipient column

### DIFF
--- a/backend/src/main/java/com/example/backend/UserProfile.java
+++ b/backend/src/main/java/com/example/backend/UserProfile.java
@@ -5,9 +5,14 @@ import jakarta.validation.constraints.Email;
 import java.util.HashSet;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @Entity
 @Table(name = "user_profiles", uniqueConstraints = @UniqueConstraint(columnNames = "username"))
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class UserProfile {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/example/backend/jamiah/Jamiah.java
+++ b/backend/src/main/java/com/example/backend/jamiah/Jamiah.java
@@ -3,6 +3,9 @@ package com.example.backend.jamiah;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 import lombok.Data;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -11,8 +14,10 @@ import java.util.Set;
 import java.util.UUID;
 
 @Data
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 @Entity
 @Table(name = "jamiah")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Jamiah {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/example/backend/jamiah/JamiahCycle.java
+++ b/backend/src/main/java/com/example/backend/jamiah/JamiahCycle.java
@@ -2,6 +2,9 @@ package com.example.backend.jamiah;
 
 import jakarta.persistence.*;
 import lombok.Data;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.example.backend.UserProfile;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -11,14 +14,16 @@ import java.util.Set;
 
 @Data
 @Entity
-@Table(name = "jamiah_cycles")
+@Table(name = "jamiah_cycle")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class JamiahCycle {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "jamiah_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "jamiah_id", nullable = false)
+    @JsonIdentityReference(alwaysAsId = true)
     private Jamiah jamiah;
 
     private Integer cycleNumber;
@@ -38,7 +43,8 @@ public class JamiahCycle {
     /** Current recipient for this round. */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recipient_id")
-    private com.example.backend.UserProfile recipient;
+    @JsonIdentityReference(alwaysAsId = true)
+    private UserProfile recipient;
 
     /** Whether the current recipient confirmed receipt. */
     private Boolean recipientConfirmed = false;

--- a/backend/src/main/resources/db/migration/V20250813__add_recipient_id_to_jamiah_cycle.sql
+++ b/backend/src/main/resources/db/migration/V20250813__add_recipient_id_to_jamiah_cycle.sql
@@ -1,0 +1,8 @@
+ALTER TABLE jamiah_cycle
+  ADD COLUMN recipient_id BIGINT NULL;
+
+ALTER TABLE jamiah_cycle
+  ADD CONSTRAINT fk_jc_recipient
+  FOREIGN KEY (recipient_id) REFERENCES user_profiles(id);
+
+CREATE INDEX idx_jc_recipient_id ON jamiah_cycle(recipient_id);


### PR DESCRIPTION
## Summary
- Serialize JamiahCycle relationships by ID to prevent Hibernate proxy serialization
- Define entity identity for Jamiah and UserProfile via JsonIdentityInfo
- Correct Flyway migration to add recipient_id column and index on jamiah_cycle table

## Testing
- `cd backend && ./mvnw -q test` (fails: Non-resolvable parent POM - network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_689c5b0565348333b464909d89caddea