### PR TITLE
fix: use set-cloudsql-instances for cloud run redeploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,4 +107,4 @@ jobs:
           flags: |
             --platform=managed
             --allow-unauthenticated
-            --add-cloudsql-instances=${{ secrets.GCP_PROJECT }}:europe-west3:mansa-db
+            --set-cloudsql-instances=${{ secrets.GCP_PROJECT }}:europe-west3:mansa-db


### PR DESCRIPTION
## Summary
- avoid redeploy failures by replacing add-cloudsql-instances with set-cloudsql-instances in Cloud Run deploy

## Testing
- `./mvnw -q test` *(failed: Non-resolvable parent POM, network is unreachable)*
- `npm ci`
- `CI=true npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689c69538dd883338b85404d7b0a89a8